### PR TITLE
Using ListingGenerator Everywhere

### DIFF
--- a/apraw/models/listing_generator.py
+++ b/apraw/models/listing_generator.py
@@ -7,11 +7,12 @@ from .subreddit import Subreddit, ModAction
 
 class ListingGenerator:
 
-    def __init__(self, reddit, endpoint, max_wait=16, kind_filter=[]):
+    def __init__(self, reddit, endpoint, max_wait=16, kind_filter=[], subreddit=None):
         self.reddit = reddit
         self.endpoint = endpoint
         self.max_wait = max_wait
         self.kind_filter = kind_filter
+        self.subreddit = subreddit
 
     async def get(self, limit=25, **kwargs):
         reddit = self.reddit
@@ -36,13 +37,13 @@ class ListingGenerator:
                     continue
 
                 if i["kind"] == reddit.link_kind:
-                    yield Submission(reddit, i["data"])
+                    yield Submission(reddit, i["data"], subreddit=self.subreddit)
                 elif i["kind"] == reddit.subreddit_kind:
                     yield Subreddit(self.reddit, i["data"])
                 elif i["kind"] == reddit.comment_kind:
                     yield Comment(self.reddit, i["data"])
                 elif i["kind"] == reddit.modaction_kind:
-                    yield ModAction(self.reddit, i["data"])
+                    yield ModAction(i["data"], self.subreddit)
             if limit is not None and limit < 1:
                 break
 

--- a/apraw/models/listing_generator.py
+++ b/apraw/models/listing_generator.py
@@ -32,7 +32,7 @@ class ListingGenerator:
 
                 if limit is not None: limit -= 1
 
-                if len(self.kind_filter) > 0 and i["kind"] not in self.kind_filter:
+                if self.kind_filter and i["kind"] not in self.kind_filter:
                     continue
 
                 if i["kind"] == reddit.link_kind:

--- a/apraw/models/listing_generator.py
+++ b/apraw/models/listing_generator.py
@@ -44,6 +44,8 @@ class ListingGenerator:
                     yield Comment(self.reddit, i["data"])
                 elif i["kind"] == reddit.modaction_kind:
                     yield ModAction(i["data"], self.subreddit)
+                else:
+                    yield i
             if limit is not None and limit < 1:
                 break
 

--- a/apraw/models/redditor.py
+++ b/apraw/models/redditor.py
@@ -51,6 +51,16 @@ class Redditor:
         else:
             self.subreddit = None
 
+        from .listing_generator import ListingGenerator
+        self.comments = ListingGenerator(
+            self.reddit,
+            API_PATH["user_comments"].format(
+                user=self))
+        self.submissions = ListingGenerator(
+            self.reddit,
+            API_PATH["user_submissions"].format(
+                user=self))
+
     def __str__(self):
         return self.name
 
@@ -61,13 +71,3 @@ class Redditor:
 
     async def message(self, subject, text, from_sr=""):
         return await self.reddit.message(self.name, subject, text, from_sr)
-
-    async def comments(self, limit=25, **kwargs):
-        async for s in self.reddit.get_listing(API_PATH["user_comments"].format(user=self), limit, **kwargs):
-            if s["kind"] == self.reddit.comment_kind:
-                yield Comment(self.reddit, s["data"])
-
-    async def submissions(self, limit=25, **kwargs):
-        async for s in self.reddit.get_listing(API_PATH["user_submissions"].format(user=self), limit, **kwargs):
-            if s["kind"] == self.reddit.link_kind:
-                yield Submission(self.reddit, s["data"])

--- a/apraw/reddit.py
+++ b/apraw/reddit.py
@@ -45,28 +45,6 @@ class Reddit:
     async def get_request(self, endpoint="", **kwargs):
         return await self.request_handler.get_request(endpoint, **kwargs)
 
-    async def get_listing(self, endpoint, limit, **kwargs):
-        last = None
-        while True:
-            kwargs["limit"] = limit if limit is not None else 100
-            if last is not None:
-                kwargs["after"] = last
-            req = await self.get_request(endpoint, **kwargs)
-            if len(req["data"]["children"]) <= 0:
-                break
-            for i in req["data"]["children"]:
-                if i["kind"] in [self.link_kind,
-                                 self.subreddit_kind, self.comment_kind]:
-                    last = i["data"]["name"]
-                elif i["kind"] == self.modaction_kind:
-                    last = i["data"]["id"]
-
-                if limit is not None:
-                    limit -= 1
-                yield i
-            if limit is not None and limit < 1:
-                break
-
     async def post_request(self, endpoint="", url="", data={}, **kwargs):
         return await self.request_handler.post_request(endpoint, url, data, **kwargs)
 

--- a/tests/integration/models/test_subreddit.py
+++ b/tests/integration/models/test_subreddit.py
@@ -1,5 +1,7 @@
 import pytest
 
+import apraw
+
 
 class TestSubreddit:
     @pytest.mark.asyncio
@@ -18,3 +20,27 @@ class TestSubreddit:
                 break
 
         assert moderator_found
+
+    @pytest.mark.asyncio
+    async def test_subreddit_moderation_listing(self, reddit):
+        subreddit = await reddit.subreddit("aprawtest")
+        report = None
+
+        async for rep in subreddit.mod.reports():
+            report = rep
+            break
+
+        assert isinstance(
+            report, apraw.models.submission.Submission) or isinstance(
+            report, apraw.models.comment.Comment)
+
+    @pytest.mark.asyncio
+    async def test_subreddit_moderation_log(self, reddit):
+        subreddit = await reddit.subreddit("aprawtest")
+        log = None
+
+        async for l in subreddit.mod.log():
+            log = l
+            break
+
+        assert isinstance(log, apraw.models.subreddit.ModAction)


### PR DESCRIPTION
Replaced the usage of `Reddit.get_listing()` in the following:
 - `apraw.models.SubredditModeration.reports()`
 - `apraw.models.SubredditModeration.spam()`
 - `apraw.models.SubredditModeration.modqueue()`
 - `apraw.models.SubredditModeration.unmoderated()`
 - `apraw.models.SubredditModeration.edited()`
 - `apraw.models.Redditor.comments()`
 - `apraw.models.Redditor.submissions()`

This allows them to be streamed and eliminates duplicate code. Also added a clause to the listing generator's if-statement to return the full data if type is unknown and implemented dependency injection for the `subreddit` into certain models (`Submission` and `ModAction`) if it's known.

Also added the following tests:
 - `test_subreddit_moderation_listing`
 - `test_subreddit_moderation_log`