### PR TITLE
Enhanced OAuth2 Flow

### DIFF
--- a/apraw/models/user.py
+++ b/apraw/models/user.py
@@ -1,5 +1,7 @@
 from datetime import datetime
 
+import aiohttp
+
 from ..endpoints import API_PATH
 from .redditor import Redditor
 
@@ -19,6 +21,9 @@ class User:
             raise Exception(
                 "No login information given or login information incomplete.")
 
+        self._auth_session = None
+        self._client_session = None
+
         self._auth_user = None
 
         self.access_data = None
@@ -27,6 +32,19 @@ class User:
         self.ratelimit_remaining = 0
         self.ratelimit_used = 0
         self.ratelimit_reset = datetime.now()
+
+    async def get_auth_session(self):
+        if self._auth_session is None:
+            auth = aiohttp.BasicAuth(
+                login=self.client_id,
+                password=self.client_secret)
+            self._auth_session = aiohttp.ClientSession(auth=auth)
+        return self._auth_session
+
+    async def get_client_session(self):
+        if self._client_session is None:
+            self._client_session = aiohttp.ClientSession()
+        return self._client_session
 
     async def me(self):
         if not self._auth_user:

--- a/apraw/models/user.py
+++ b/apraw/models/user.py
@@ -21,6 +21,8 @@ class User:
             raise Exception(
                 "No login information given or login information incomplete.")
 
+        self.password_grant = "grant_type=password&username={}&password={}".format(self.username, self.password)
+
         self._auth_session = None
         self._client_session = None
 

--- a/apraw/reddit.py
+++ b/apraw/reddit.py
@@ -123,14 +123,14 @@ class RequestHandler:
     async def get_request_headers(self):
         if self.user.token_expires <= datetime.now():
             url = "https://www.reddit.com/api/v1/access_token"
-            data = {
-                "grant_type": "password",
-                "username": self.user.username,
-                "password": self.user.password
+            session = await self.user.get_auth_session()
+
+            headers = {
+                "Content-Type": "application/x-www-form-urlencoded",
+                "User-Agent": self.user.user_agent
             }
 
-            session = await self.user.get_auth_session()
-            resp = await session.post(url, data=data)
+            resp = await session.post(url, data=self.user.password_grant, headers=headers)
 
             async with resp:
                 if resp.status == 200:


### PR DESCRIPTION
Fixes #42 

## Feature Summary
> Explain what's new in this pull request.

 - `aiohttp.ClientSession()` only created twice; one with authorization headers for getting tokens, and one for regular requests.
   - Stored in `apraw.models.User` and retrievable via `get_auth_session()` and `get_client_session()`
 - Update auth flow, set data as string format and set headers including `Content-Type` to `application/x-www-form-urlencoded`.
   - This should fix authentication on Debian-based systems.