### PR TITLE
Listing Generator Stream Skip Existing

### DIFF
--- a/apraw/models/listing_generator.py
+++ b/apraw/models/listing_generator.py
@@ -78,13 +78,19 @@ class ListingGenerator:
 
     __call__ = get
 
-    async def stream(self, **kwargs) -> AsyncIterator[aPRAWBase]:
+    async def stream(self, skip_existing: bool = False, **kwargs) -> AsyncIterator[aPRAWBase]:
         wait = 0
+        first = True
         ids = list()
 
         while True:
             found = False
             async for s in self.get(100, **kwargs):
+                if first:
+                    if skip_existing:
+                        ids.append(s.id)
+                        break
+                    first = False
                 if s.id in ids:
                     break
                 if len(ids) >= 301:

--- a/apraw/models/listing_generator.py
+++ b/apraw/models/listing_generator.py
@@ -1,3 +1,4 @@
+
 import asyncio
 from typing import TYPE_CHECKING, Any, AsyncIterator, Callable, List, Union
 
@@ -80,17 +81,16 @@ class ListingGenerator:
 
     async def stream(self, skip_existing: bool = False, **kwargs) -> AsyncIterator[aPRAWBase]:
         wait = 0
-        first = True
         ids = list()
+
+        if skip_existing:
+            async for s in self.get(1, **kwargs):
+                ids.append(s.id)
+                break
 
         while True:
             found = False
             async for s in self.get(100, **kwargs):
-                if first:
-                    if skip_existing:
-                        ids.append(s.id)
-                        break
-                    first = False
                 if s.id in ids:
                     break
                 if len(ids) >= 301:

--- a/tests/integration/models/test_listing_generator.py
+++ b/tests/integration/models/test_listing_generator.py
@@ -1,4 +1,8 @@
+from datetime import datetime
+
 import pytest
+
+import apraw
 
 
 class TestListingGenerator:
@@ -6,14 +10,9 @@ class TestListingGenerator:
     async def test_listing_generator_get(self, reddit):
         subreddit = await reddit.subreddit("aprawtest")
         listing_generator = subreddit.new
-        submission_found = False
 
         async for submission in listing_generator.get():
-            if submission.id == "h7mna9":
-                submission_found = True
-                break
-
-        assert submission_found
+            assert isinstance(submission, apraw.models.Submission)
 
     @pytest.mark.asyncio
     async def test_listing_generator_call(self, reddit):
@@ -23,13 +22,20 @@ class TestListingGenerator:
 
     @pytest.mark.asyncio
     async def test_listing_generator_stream(self, reddit):
-        subreddit = await reddit.subreddit("aprawtest")
+        subreddit = await reddit.subreddit("askreddit")
         listing_generator = subreddit.new
-        submission_found = False
 
+        i = 0
         async for submission in listing_generator.stream():
-            if submission.id == "h7mna9":
-                submission_found = True
-                break
+            i += 1
+            assert isinstance(submission, apraw.models.Submission)
+            if i >= 5: break
 
-        assert submission_found
+        time_started = datetime.utcnow()
+
+        i = 0
+        async for submission in listing_generator.stream(True):
+            i += 1
+            assert isinstance(submission, apraw.models.Submission)
+            assert submission.created_utc >= time_started
+            if i >= 5: break


### PR DESCRIPTION
Closes #48 

## Feature Summary
> Explain what's new in this pull request.

 - Add `skip_existing` to `ListingGenerator.stream()` arguments to only return new items. 
   - **Note:** This feature only works correctly with the `/new` endpoints as eventually the limit of 300 saved IDs will be overriden and old items might reappear.

## Tests Added
> Describe tests if any were written.

 - Updated listing generator tests to test `skip_existing`.