### PR TITLE
Update Streamable Decorator

### DIFF
--- a/apraw/models/__init__.py
+++ b/apraw/models/__init__.py
@@ -3,7 +3,7 @@ from .helpers.apraw_base import aPRAWBase
 from .helpers.generator import ListingGenerator
 from .helpers.item_moderation import ItemModeration, PostModeration
 from .helpers.listing import Listing
-from .helpers.streamable import streamable
+from .helpers.streamable import Streamable
 from .modmail import ModmailConversation, ModmailMessage, SubredditModmail
 from .redditor import Redditor
 from .submission import Submission, SubmissionModeration

--- a/apraw/models/helpers/streamable.py
+++ b/apraw/models/helpers/streamable.py
@@ -19,18 +19,21 @@ class Streamable:
 
     @classmethod
     def streamable(cls,
-                   func: Union[Callable[[Any, int, Any], AsyncIterator[aPRAWBase]], AsyncGenerator[aPRAWBase]] = None,
+                   func: Union[
+                       Callable[[Any, int, Any], AsyncIterator[aPRAWBase]], AsyncGenerator[aPRAWBase, None]] = None,
                    max_wait: int = 16,
                    attribute_name: str = "fullname"):
         if func:
             return Streamable(func)
         else:
-            def wrapper(_func: Union[Callable[[Any, int, Any], AsyncIterator[aPRAWBase]], AsyncGenerator[aPRAWBase]]):
+            def wrapper(
+                    _func: Union[Callable[[Any, int, Any], AsyncIterator[aPRAWBase]], AsyncGenerator[aPRAWBase, None]]):
                 return Streamable(_func, max_wait, attribute_name)
 
             return wrapper
 
-    def __init__(self, func: Union[Callable[[Any, int, Any], AsyncIterator[aPRAWBase]], AsyncGenerator[aPRAWBase]],
+    def __init__(self,
+                 func: Union[Callable[[Any, int, Any], AsyncIterator[aPRAWBase]], AsyncGenerator[aPRAWBase, None]],
                  max_wait: int = 16,
                  attribute_name: str = "fullname"):
         """

--- a/apraw/models/helpers/streamable.py
+++ b/apraw/models/helpers/streamable.py
@@ -61,7 +61,7 @@ class Streamable:
         self.instance = instance
         return self
 
-    def __call__(self, *args, **kwargs):
+    async def __call__(self, *args, **kwargs):
         """
         Make streamable callable to return result of decorated function.
         """

--- a/apraw/models/helpers/streamable.py
+++ b/apraw/models/helpers/streamable.py
@@ -65,7 +65,8 @@ class Streamable:
         """
         Make streamable callable to return result of decorated function.
         """
-        return self.func(self.instance, *args, **kwargs)
+        async for item in self.func(self.instance, *args, **kwargs):
+            yield item
 
     async def stream(self, skip_existing: bool = False, *args, **kwargs):
         """

--- a/apraw/models/helpers/streamable.py
+++ b/apraw/models/helpers/streamable.py
@@ -1,12 +1,11 @@
 import asyncio
 from functools import update_wrapper
-from typing import AsyncIterator, Callable, Any
+from typing import AsyncIterator, Callable, Any, Union, AsyncGenerator
 
 from .apraw_base import aPRAWBase
 
 
-# noinspection PyPep8Naming
-class streamable:
+class Streamable:
     """
     A decorator to make functions returning a generator streamable.
 
@@ -18,7 +17,21 @@ class streamable:
         The attribute name to use as a unique identifier for returned objects.
     """
 
-    def __init__(self, func: Callable[[Any, int, Any], AsyncIterator[Any]], max_wait: int = 16,
+    @classmethod
+    def streamable(cls,
+                   func: Union[Callable[[Any, int, Any], AsyncIterator[aPRAWBase]], AsyncGenerator[aPRAWBase]] = None,
+                   max_wait: int = 16,
+                   attribute_name: str = "fullname"):
+        if func:
+            return Streamable(func)
+        else:
+            def wrapper(_func: Union[Callable[[Any, int, Any], AsyncIterator[aPRAWBase]], AsyncGenerator[aPRAWBase]]):
+                return Streamable(_func, max_wait, attribute_name)
+
+            return wrapper
+
+    def __init__(self, func: Union[Callable[[Any, int, Any], AsyncIterator[aPRAWBase]], AsyncGenerator[aPRAWBase]],
+                 max_wait: int = 16,
                  attribute_name: str = "fullname"):
         """
         Create an instance of the streamable object.

--- a/apraw/models/helpers/streamable.py
+++ b/apraw/models/helpers/streamable.py
@@ -100,14 +100,14 @@ class Streamable:
         seen_attributes = list()
 
         if skip_existing:
-            items = [i async for i in self(self.instance, 1, *args, **kwargs)]
+            items = [i async for i in self(1, *args, **kwargs)]
             for item in reversed(items):
                 seen_attributes.append(getattr(item, self.attribute_name))
                 break
 
         while True:
             found = False
-            items = [i async for i in self(self.instance, 100, *args, **kwargs)]
+            items = [i async for i in self(100, *args, **kwargs)]
             for item in reversed(items):
                 attribute = getattr(item, self.attribute_name)
 

--- a/apraw/models/redditor.py
+++ b/apraw/models/redditor.py
@@ -1,7 +1,7 @@
 from typing import TYPE_CHECKING, Dict
 
 from .helpers.apraw_base import aPRAWBase
-from .helpers.streamable import streamable
+from .helpers.streamable import Streamable
 from ..endpoints import API_PATH
 
 if TYPE_CHECKING:
@@ -83,7 +83,7 @@ class Redditor(aPRAWBase):
         else:
             self.subreddit = None
 
-    @streamable
+    @Streamable.streamable
     def comments(self, *args, **kwargs):
         """
         Returns an instance of :class:`~apraw.models.ListingGenerator` mapped to fetch the Redditor's comments.
@@ -109,7 +109,7 @@ class Redditor(aPRAWBase):
         from .helpers.generator import ListingGenerator
         return ListingGenerator(self.reddit, API_PATH["user_comments"].format(user=self), *args, **kwargs)
 
-    @streamable
+    @Streamable.streamable
     def submissions(self, *args, **kwargs):
         """
         Returns an instance of :class:`~apraw.models.ListingGenerator` mapped to fetch the Redditor's submissions.

--- a/apraw/models/subreddit.py
+++ b/apraw/models/subreddit.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from typing import TYPE_CHECKING, AsyncIterator, Dict, Union
 
 from .helpers.apraw_base import aPRAWBase
-from .helpers.streamable import streamable
+from .helpers.streamable import Streamable
 from .modmail import SubredditModmail
 from .redditor import Redditor
 from .subreddit_wiki import SubredditWiki
@@ -160,7 +160,7 @@ class Subreddit(aPRAWBase):
         self.modmail = SubredditModmail(self)
         self.wiki = SubredditWiki(self)
 
-    @streamable
+    @Streamable.streamable
     def comments(self, *args, **kwargs):
         """
         Returns an instance of :class:`~apraw.models.ListingGenerator` mapped to the comments endpoint.
@@ -187,7 +187,7 @@ class Subreddit(aPRAWBase):
         return ListingGenerator(self.reddit, API_PATH["subreddit_comments"].format(sub=self.display_name),
                                 subreddit=self, *args, **kwargs)
 
-    @streamable
+    @Streamable.streamable
     def new(self, *args, **kwargs):
         """
         Returns an instance of :class:`~apraw.models.ListingGenerator` mapped to the new submissions endpoint.
@@ -399,7 +399,7 @@ class SubredditModeration:
         """
         self.subreddit = subreddit
 
-    @streamable
+    @Streamable.streamable
     def reports(self, *args, **kwargs):
         """
         Returns an instance of :class:`~apraw.models.ListingGenerator` mapped to grab reported items.
@@ -427,7 +427,7 @@ class SubredditModeration:
                                 API_PATH["subreddit_reports"].format(sub=self.subreddit.display_name),
                                 subreddit=self.subreddit, *args, **kwargs)
 
-    @streamable
+    @Streamable.streamable
     def spam(self, *args, **kwargs):
         """
         Returns an instance of :class:`~apraw.models.ListingGenerator` mapped to grab items marked as spam.
@@ -455,7 +455,7 @@ class SubredditModeration:
                                 API_PATH["subreddit_spam"].format(sub=self.subreddit.display_name),
                                 subreddit=self.subreddit, *args, **kwargs)
 
-    @streamable
+    @Streamable.streamable
     def modqueue(self, *args, **kwargs):
         """
         Returns an instance of :class:`~apraw.models.ListingGenerator` mapped to grab items in the modqueue.
@@ -483,7 +483,7 @@ class SubredditModeration:
                                 API_PATH["subreddit_modqueue"].format(sub=self.subreddit.display_name),
                                 subreddit=self.subreddit, *args, **kwargs)
 
-    @streamable
+    @Streamable.streamable
     def unmoderated(self, *args, **kwargs):
         """
         Returns an instance of :class:`~apraw.models.ListingGenerator` mapped to grab unmoderated items.
@@ -511,7 +511,7 @@ class SubredditModeration:
                                 API_PATH["subreddit_unmoderated"].format(sub=self.subreddit.display_name),
                                 subreddit=self.subreddit, *args, **kwargs)
 
-    @streamable
+    @Streamable.streamable
     def edited(self, *args, **kwargs):
         """
         Returns an instance of :class:`~apraw.models.ListingGenerator` mapped to grab edited items.
@@ -539,7 +539,7 @@ class SubredditModeration:
                                 API_PATH["subreddit_edited"].format(sub=self.subreddit.display_name),
                                 subreddit=self.subreddit, *args, **kwargs)
 
-    @streamable
+    @Streamable.streamable
     def log(self, *args, **kwargs):
         """
         Returns an instance of :class:`~apraw.models.ListingGenerator` mapped to grab mod actions in the subreddit log.

--- a/apraw/models/subreddit_wiki.py
+++ b/apraw/models/subreddit_wiki.py
@@ -1,7 +1,7 @@
 from typing import TYPE_CHECKING, Dict, List, Union
 
 from .helpers.apraw_base import aPRAWBase
-from .helpers.streamable import streamable
+from .helpers.streamable import Streamable
 from .redditor import Redditor
 from ..endpoints import API_PATH
 
@@ -16,7 +16,7 @@ class SubredditWiki:
         self.subreddit = subreddit
         self._data = None
 
-    @streamable
+    @Streamable.streamable
     def revisions(self, *args, **kwargs):
         """
         Returns an instance of :class:`~apraw.models.ListingGenerator` mapped to recent wikipage revisions.
@@ -76,7 +76,7 @@ class SubredditWikipage(aPRAWBase):
         self.name = name
         self.subreddit = subreddit
 
-    @streamable
+    @Streamable.streamable
     def revisions(self, *args, **kwargs):
         """
         Returns an instance of :class:`~apraw.models.ListingGenerator` mapped to fetch specific wikipage revisions.

--- a/apraw/reddit.py
+++ b/apraw/reddit.py
@@ -7,7 +7,7 @@ from typing import Any, Awaitable, Callable, Dict, List, Union
 
 from .endpoints import API_PATH, BASE_URL
 from .models import (Comment, Listing, Redditor, Submission,
-                     Subreddit, User, ListingGenerator, streamable)
+                     Subreddit, User, ListingGenerator, Streamable)
 from .utils import prepend_kind
 
 
@@ -66,7 +66,7 @@ class Reddit:
 
         self.request_handler = RequestHandler(self.user)
 
-    @streamable
+    @Streamable.streamable
     def subreddits(self, *args, **kwargs):
         """
         A :class:`~apraw.models.ListingGenerator` that returns newly created subreddits, which can be streamed using :code:`reddit.subreddits.stream()`.

--- a/tests/unit/models/helpers/test_streamable.py
+++ b/tests/unit/models/helpers/test_streamable.py
@@ -1,0 +1,120 @@
+import pytest
+
+from apraw.models import Streamable
+
+
+class TestStreamable:
+    @pytest.mark.asyncio
+    async def test_streamable_async_generator(self):
+        items = list(range(20))
+
+        async def async_generator():
+            for i in items:
+                yield i
+
+        streamable = Streamable(async_generator)
+        result = [i async for i in streamable()]
+        assert result == items
+
+    @pytest.mark.asyncio
+    async def test_streamable_sync_generator(self):
+        items = list(range(20))
+
+        def sync_generator():
+            for i in items:
+                yield i
+
+        streamable = Streamable(sync_generator)
+        result = [i async for i in streamable()]
+        assert result == items
+
+    @pytest.mark.asyncio
+    async def test_streamable_async_list(self):
+        items = list(range(20))
+
+        async def get_list():
+            return items
+
+        streamable = Streamable(get_list)
+        result = [i async for i in streamable()]
+        assert result == items
+
+    @pytest.mark.asyncio
+    async def test_streamable_sync_list(self):
+        items = list(range(20))
+
+        def get_list():
+            return items
+
+        streamable = Streamable(get_list)
+        result = [i async for i in streamable()]
+        assert result == items
+
+    @pytest.mark.asyncio
+    async def test_streamable_async_list(self):
+        items = list(range(20))
+
+        async def get_list():
+            return items
+
+        streamable = Streamable(get_list)
+        result = [i async for i in streamable()]
+        assert result == items
+
+    @pytest.mark.asyncio
+    async def test_streamable_sync_async_iterator(self):
+        items = list(range(20))
+
+        def get_async_iterator():
+            class AIterator:
+                def __init__(self):
+                    self._index = 0
+                    self._items = items
+
+                def __aiter__(self):
+                    return self
+
+                def __len__(self):
+                    return len(self._items)
+
+                async def __anext__(self):
+                    if self._index >= len(self):
+                        raise StopAsyncIteration
+
+                    self._index += 1
+                    return self._items[self._index - 1]
+
+            return AIterator()
+
+        streamable = Streamable(get_async_iterator)
+        result = [i async for i in streamable()]
+        assert result == items
+
+    @pytest.mark.asyncio
+    async def test_streamable_async_async_iterator(self):
+        items = list(range(20))
+
+        async def get_async_iterator():
+            class AIterator:
+                def __init__(self):
+                    self._index = 0
+                    self._items = items
+
+                def __aiter__(self):
+                    return self
+
+                def __len__(self):
+                    return len(self._items)
+
+                async def __anext__(self):
+                    if self._index >= len(self):
+                        raise StopAsyncIteration
+
+                    self._index += 1
+                    return self._items[self._index - 1]
+
+            return AIterator()
+
+        streamable = Streamable(get_async_iterator)
+        result = [i async for i in streamable()]
+        assert result == items

--- a/tests/unit/models/helpers/test_streamable.py
+++ b/tests/unit/models/helpers/test_streamable.py
@@ -5,6 +5,18 @@ from apraw.models import Streamable
 
 class TestStreamable:
     @pytest.mark.asyncio
+    async def test_streamable_parameters(self):
+        items = list(range(20))
+
+        @Streamable.streamable(max_wait=12)
+        async def async_generator():
+            for i in items:
+                yield i
+
+        result = [i async for i in async_generator()]
+        assert result == items
+
+    @pytest.mark.asyncio
     async def test_streamable_async_generator(self):
         items = list(range(20))
 


### PR DESCRIPTION
Fixes #67 

## Feature Summary
> Explain what's new in this pull request.

 - Rework `@streamable` decorator to `@Streamable.streamable` with classmethod as wrapper.
    - Enable decorator parameters `wait_time` and `attribute_name`.
 - Make `Streamable` compatible with sync/async generators, as well as sync/async callables returning sync/async iterables.
 - Update typing.

## Tests Added
> Describe tests if any were written.

**Unit tests:**
 - `test_streamable_parameters`
 - `test_streamable_async_generator`
 - `test_streamable_sync_generator`
 - `test_streamable_async_list`
 - `test_streamable_sync_list`
 - `test_streamable_async_list`
 - `test_streamable_sync_async_iterator`
 - `test_streamable_async_async_iterator`