### PR TITLE
Make aPRAWBase Lazy

### DIFF
--- a/apraw/models/__init__.py
+++ b/apraw/models/__init__.py
@@ -1,9 +1,9 @@
 from .helpers.apraw_base import aPRAWBase
 from .helpers.generator import ListingGenerator
 from .helpers.item_moderation import ItemModeration, PostModeration
-from .helpers.listing import Listing
 from .helpers.streamable import Streamable
 from .reddit.comment import Comment
+from .reddit.listing import Listing
 from .reddit.message import Message
 from .reddit.redditor import Redditor
 from .reddit.submission import Submission

--- a/apraw/models/helpers/apraw_base.py
+++ b/apraw/models/helpers/apraw_base.py
@@ -16,15 +16,13 @@ class aPRAWBase:
 
     Members
     -------
-    reddit: Reddit
-        The :class:`~apraw.Reddit` instance with which requests are made.
-    data: Dict
-        The data obtained from the /about endpoint.
     kind: str
         The item's kind / type.
     """
 
-    def __init__(self, reddit: 'Reddit', data: Dict[str, Any], kind: str = ""):
+    ID_ATTRIBUTE = "id"
+
+    def __init__(self, reddit: 'Reddit', data: Dict[str, Any] = None, kind: str = ""):
         """
         Initialize the base information.
 
@@ -35,9 +33,11 @@ class aPRAWBase:
         data: Dict
             The data obtained from the /about endpoint.
         """
-        self.reddit = reddit
+        self._reddit = reddit
         self.kind = kind
-        self._update(data)
+
+        if data:
+            self._update(data)
 
     def _update(self, data: Dict[str, Any]):
         """
@@ -48,7 +48,7 @@ class aPRAWBase:
         data: Dict
             The data obtained from the /about endpoint.
         """
-        self.data = data
+        self._data = data
 
         d = snake_case_keys(data)
         for key in d:
@@ -58,8 +58,17 @@ class aPRAWBase:
         if "created_utc" in data:
             self.created_utc = datetime.utcfromtimestamp(data["created_utc"])
 
+    async def fetch(self):
+        """
+        Fetch this item's information from a suitable API endpoint.
+
+        Returns
+        -------
+        self: aPRAWBase
+            The updated model.
+        """
+        raise NotImplementedError
+
     @property
     def fullname(self):
-        return prepend_kind(self.name if hasattr(
-            self, "name") else self.id, self.kind) if self.kind else self.name if hasattr(
-            self, "name") else self.id
+        return prepend_kind(self._data[self.ID_ATTRIBUTE], self.kind) if self.kind else self._data[self.ID_ATTRIBUTE]

--- a/apraw/models/helpers/apraw_base.py
+++ b/apraw/models/helpers/apraw_base.py
@@ -69,6 +69,17 @@ class aPRAWBase:
         """
         raise NotImplementedError
 
+    def __repr__(self):
+        """
+        Get a representational string for this model following the pattern ``<{class} {id_attribute}='{id}'>``.
+
+        Returns
+        -------
+        repr: string
+            A printable representational string for this model.
+        """
+        return f"<{self.__class__.__name__} {self.ID_ATTRIBUTE}='{self._data[self.ID_ATTRIBUTE]}'>"
+
     @property
     def fullname(self):
         return prepend_kind(self._data[self.ID_ATTRIBUTE], self.kind) if self.kind else self._data[self.ID_ATTRIBUTE]

--- a/apraw/models/helpers/listing.py
+++ b/apraw/models/helpers/listing.py
@@ -113,21 +113,25 @@ class Listing(aPRAWBase, Iterator):
         data = getattr(self, self.CHILD_ATTRIBUTE)[index]
 
         if "page" in data:
-            item = WikipageRevision(self.reddit, data)
-        elif data["kind"] == self.reddit.link_kind:
-            item = Submission(self.reddit, data["data"], subreddit=self._subreddit)
-        elif data["kind"] == self.reddit.subreddit_kind:
-            item = Subreddit(self.reddit, data["data"])
-        elif data["kind"] == self.reddit.comment_kind:
-            item = Comment(self.reddit, data["data"], subreddit=self._subreddit)
-        elif data["kind"] == self.reddit.modaction_kind:
-            item = ModAction(self.reddit, data["data"], self._subreddit)
-        elif data["kind"] == self.reddit.message_kind:
-            item = Message(self.reddit, data["data"])
+            return WikipageRevision(self._reddit, data)
+        elif data["kind"] == self._reddit.link_kind:
+            return Submission(self._reddit, data["data"], subreddit=self._subreddit)
+        elif data["kind"] == self._reddit.subreddit_kind:
+            return Subreddit(self._reddit, data["data"])
+        elif data["kind"] == self._reddit.comment_kind:
+            if data["data"]["replies"] and data["data"]["replies"]["kind"] == self._reddit.listing_kind:
+                replies = [reply for reply in Listing(self._reddit, data["data"]["replies"]["data"])]
+            else:
+                replies = []
+            return Comment(self._reddit, data["data"], subreddit=self._subreddit, replies=replies)
+        elif data["kind"] == self._reddit.modaction_kind:
+            return ModAction(self._reddit, data["data"], self._subreddit)
+        elif data["kind"] == self._reddit.message_kind:
+            return Message(self._reddit, data["data"])
+        elif data["kind"] == self._reddit.listing_kind:
+            return Listing(self._reddit, data["data"])
         else:
-            item = aPRAWBase(self.reddit, data["data"] if "data" in data else data)
-
-        return item
+            return aPRAWBase(self._reddit, data["data"] if "data" in data else data)
 
     @property
     def last(self) -> aPRAWBase:

--- a/apraw/models/mixins/author.py
+++ b/apraw/models/mixins/author.py
@@ -19,5 +19,5 @@ class AuthorMixin:
             The item's author.
         """
         if self._author is None:
-            self._author = await self.reddit.redditor(self.data["author"])
+            self._author = await self._reddit.redditor(self._data["author"])
         return self._author

--- a/apraw/models/mixins/deletable.py
+++ b/apraw/models/mixins/deletable.py
@@ -15,4 +15,4 @@ class DeletableMixin:
         resp: Dict
             The API response JSON.
         """
-        return await self.reddit.post_request(API_PATH["post_delete"], id=self.fullname)
+        return await self._reddit.post_request(API_PATH["post_delete"], id=self.fullname)

--- a/apraw/models/mixins/replyable.py
+++ b/apraw/models/mixins/replyable.py
@@ -21,14 +21,14 @@ class ReplyableMixin:
         reply: Comment or Message
             The newly created reply, either a :class:`~apraw.models.Comment` or :class:`~apraw.models.Message`.
         """
-        resp = await self.reddit.post_request(API_PATH["reply"], text=text, return_rtjson=True, thing_id=self.fullname)
+        resp = await self._reddit.post_request(API_PATH["reply"], text=text, return_rtjson=True, thing_id=self.fullname)
 
-        if self.kind == self.reddit.message_kind:
+        if self.kind == self._reddit.message_kind:
             from ..reddit.message import Message
-            reply = Message(self.reddit, resp)
+            reply = Message(self._reddit, resp)
         else:
             from ..reddit.comment import Comment
-            reply = Comment(self.reddit, resp)
+            reply = Comment(self._reddit, resp)
 
         return reply
 

--- a/apraw/models/mixins/subreddit.py
+++ b/apraw/models/mixins/subreddit.py
@@ -19,5 +19,5 @@ class SubredditMixin:
             The subreddit this item was made in.
         """
         if self._subreddit is None:
-            self._subreddit = await self.reddit.subreddit(self.data["subreddit"])
+            self._subreddit = await self._reddit.subreddit(self._data["subreddit"])
         return self._subreddit

--- a/apraw/models/reddit/comment.py
+++ b/apraw/models/reddit/comment.py
@@ -181,7 +181,7 @@ class Comment(aPRAWBase, DeletableMixin, HideableMixin, ReplyableMixin, SavableM
             data = _data[0]["data"]
             super()._update(data)
 
-            from ..helpers.listing import Listing
+            from .listing import Listing
             self.replies = [reply for reply in Listing(self._reddit, _data[1]["data"])]
         else:
             raise ValueError("data is not of type 'dict' or 'list'.")

--- a/apraw/models/reddit/comment.py
+++ b/apraw/models/reddit/comment.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, AsyncIterator, Dict, List
+from typing import TYPE_CHECKING, Dict, List, Any, Union
 
 from .redditor import Redditor
 from ..helpers.apraw_base import aPRAWBase
@@ -25,10 +25,6 @@ class Comment(aPRAWBase, DeletableMixin, HideableMixin, ReplyableMixin, SavableM
 
     Members
     -------
-    reddit: Reddit
-        The :class:`~apraw.Reddit` instance with which requests are made.
-    data: Dict
-        The data obtained from the /about endpoint.
     mod: CommentModeration
         The :class:`~apraw.models.CommentModeration` instance to aid in moderating the comment.
     kind: str
@@ -149,10 +145,51 @@ class Comment(aPRAWBase, DeletableMixin, HideableMixin, ReplyableMixin, SavableM
         self.mod = CommentModeration(reddit, self)
 
         self._submission = submission
-        self._full_data = None
-        self._replies = replies
+        self.replies = replies if replies else []
 
-        self.url = "https://www.reddit.com" + data["permalink"] if "permalink" in data else ""
+    async def fetch(self):
+        """
+        Fetch this item's information from a suitable API endpoint.
+
+        Returns
+        -------
+        self: Comment
+            The ``Comment`` model with updated data.
+        """
+        if hasattr(self, "url"):
+            resp = await self._reddit.get_request(self.url)
+            self._update(resp)
+        else:
+            resp = await self._reddit.get_request(API_PATH["info"], id=id)
+            self._update(resp["data"]["children"][0]["data"])
+        return self
+
+    def _update(self, _data: Union[List, Dict[str, Any]]):
+        """
+        Update the base with new information.
+
+        Parameters
+        ----------
+        _data: Dict
+            The data obtained from the /about endpoint.
+        """
+        if isinstance(_data, dict):
+            data = _data
+            super()._update(data)
+        elif isinstance(_data, list):
+            data = _data[0]["data"]
+            super()._update(data)
+
+            from ..helpers.listing import Listing
+            self.replies = [reply for reply in Listing(self._reddit, _data[1]["data"])]
+        else:
+            raise ValueError("data is not of type 'dict' or 'list'.")
+
+        if "permalink" in data:
+            self.url = "https://www.reddit.com" + data["permalink"]
+        elif "link_id" in data and "id" in data and "subreddit" in data:
+            link_id = data["link_id"].replace(self._reddit.link_kind + "_", "")
+            self.url = API_PATH["comment"].format(sub=data["subreddit"], submission=link_id, id=data["id"])
 
     async def submission(self) -> 'Submission':
         """
@@ -164,90 +201,11 @@ class Comment(aPRAWBase, DeletableMixin, HideableMixin, ReplyableMixin, SavableM
             The submission this comment was made in.
         """
         if self._submission is None:
-            link = await self.reddit.get_request(API_PATH["info"], id=self.data["link_id"])
+            link = await self._reddit.get_request(API_PATH["info"], id=self._data["link_id"])
             from .submission import Submission
             self._submission = Submission(
-                self.reddit, link["data"]["children"][0]["data"])
+                self._reddit, link["data"]["children"][0]["data"])
         return self._submission
-
-    async def full_data(self, refresh: bool = False) -> Dict:
-        """
-        Retrieve the submission's full data from the /r/{sub}/comments/{submission}/_/{id} endpoint.
-
-        Returns
-        -------
-        full_data: Dict
-            The full data retrieved from the API.
-        """
-        if self._full_data is None or refresh:
-            self._full_data = await self.reddit.get_request(
-                API_PATH["comment"].format(sub=self.data["subreddit"],
-                                           submission=self.data["link_id"].replace(
-                                               self.reddit.link_kind + "_", ""),
-                                           id=self.data["id"]))
-        return self._full_data
-
-    async def refresh(self):
-        """
-        Reload the comment's data and replies.
-
-        .. warning::
-            Refresh methods will be replaced by refreshables in future releases of aPRAW, and these methods will not be
-            available in post-alpha releases.
-
-        """
-        await self.full_data(True)
-        await self.replies(True)  # TODO: Fix
-
-    async def replies(self, refresh: bool = False) -> AsyncIterator['Comment']:
-        """
-        Retrieve this comment's replies.
-
-        .. note::
-            Replies are returned as :class:`~apraw.models.Comment` and already have their ``_replies`` recursively filled
-            with data retrieved from the request made originally. Fetching replies at a further depth will not result in
-            further calls unless specifically specified with the ``refresh`` argument.
-
-        Parameters
-        ----------
-        refresh: bool
-            Whether to force a refresh of previously fetched comments.
-
-            .. warning::
-                ``reload`` and ``refresh`` arguments will be replaced by refreshables in future releases of aPRAW, as
-                they are alpha features.
-
-        Yields
-        ------
-        reply: Comment
-            A reply to this comment.
-        """
-        if self._replies is None or refresh:
-            fd = await self.full_data()
-
-            def find(listing):
-                data = listing["data"]
-
-                for comment in data["children"]:
-                    if comment["data"]["id"] == self.id:
-                        return comment
-                    else:
-                        return find(comment["replies"])
-
-            comment = find(fd[1])
-
-            def get_replies(comment, replies=[]):
-                if "kind" in comment["replies"] and comment["replies"]["kind"] == self.reddit.listing_kind:
-                    for reply in comment["replies"]["data"]["children"]:
-                        data = reply["data"]
-                        replies.append(
-                            Comment(self.reddit, data, replies=get_replies(data, [])))
-                return replies
-
-            self._replies = get_replies(comment["data"])
-
-        for reply in self._replies:
-            yield reply
 
 
 class CommentModeration(PostModeration):

--- a/apraw/models/reddit/listing.py
+++ b/apraw/models/reddit/listing.py
@@ -1,9 +1,9 @@
 from typing import TYPE_CHECKING, Dict, Iterator, List
 
-from .apraw_base import aPRAWBase
-from ..reddit.comment import Comment
-from ..reddit.message import Message
-from ..reddit.submission import Submission
+from .comment import Comment
+from .message import Message
+from .submission import Submission
+from ..helpers.apraw_base import aPRAWBase
 from ..subreddit.moderation import ModAction
 from ..subreddit.subreddit import Subreddit
 from ..subreddit.wiki import WikipageRevision

--- a/apraw/models/reddit/redditor.py
+++ b/apraw/models/reddit/redditor.py
@@ -83,6 +83,19 @@ class Redditor(aPRAWBase):
         else:
             self.subreddit = None
 
+    async def fetch(self):
+        """
+        Fetch this item's information from a suitable API endpoint.
+
+        Returns
+        -------
+        self: Redditor
+            The updated ``Redditor``.
+        """
+        resp = await self._reddit.get_request(API_PATH["user_about"].format(user=self._data["username"]))
+        self._update(resp["data"])
+        return self
+
     @Streamable.streamable
     def comments(self, *args, **kwargs):
         r"""

--- a/apraw/models/reddit/submission.py
+++ b/apraw/models/reddit/submission.py
@@ -1,7 +1,6 @@
 from enum import Enum
-from typing import TYPE_CHECKING, AsyncIterator, Dict, List, AsyncGenerator, Any, Union
+from typing import TYPE_CHECKING, Dict, List, Any, Union
 
-from .comment import Comment
 from .redditor import Redditor
 from ..helpers.apraw_base import aPRAWBase
 from ..helpers.item_moderation import PostModeration
@@ -231,7 +230,7 @@ class Submission(aPRAWBase, DeletableMixin, HideableMixin, ReplyableMixin, NSFWa
         elif isinstance(_data, list):
             super()._update(_data[0]["data"]["children"][0])
 
-            from ..helpers.listing import Listing
+            from .listing import Listing
             self.comments = [reply for reply in Listing(self._reddit, _data[1]["data"])]
         else:
             raise ValueError("data is not of type 'dict' or 'list'.")

--- a/apraw/models/reddit/submission.py
+++ b/apraw/models/reddit/submission.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import TYPE_CHECKING, AsyncIterator, Dict, List, AsyncGenerator
+from typing import TYPE_CHECKING, AsyncIterator, Dict, List, AsyncGenerator, Any, Union
 
 from .comment import Comment
 from .redditor import Redditor
@@ -16,6 +16,7 @@ from ..mixins.subreddit import SubredditMixin
 from ..mixins.votable import VotableMixin
 from ..subreddit.subreddit import Subreddit
 from ...const import API_PATH
+from ...utils import prepend_kind
 
 if TYPE_CHECKING:
     from ...reddit import Reddit
@@ -31,7 +32,7 @@ class SubmissionKind(Enum):
     VIDEO = "video"
     VIDEOGIF = "videogif"
 
-    
+
 class Submission(aPRAWBase, DeletableMixin, HideableMixin, ReplyableMixin, NSFWableMixin, SavableMixin, VotableMixin,
                  AuthorMixin, SubredditMixin, SpoilerableMixin):
     """
@@ -197,86 +198,43 @@ class Submission(aPRAWBase, DeletableMixin, HideableMixin, ReplyableMixin, NSFWa
 
         self.original_content = data["is_original_content"]
 
-    async def full_data(self) -> Dict:
+    async def fetch(self):
         """
-        Retrieve the submission's full data from the /r/{sub}/comments/{id} endpoint.
+        Fetch this item's information from a suitable API endpoint.
 
         Returns
         -------
-        full_data: Dict
-            The full data retrieved from the /r/{sub}/comments/{id} endpoint.
+        self: Submission
+            The updated model.
         """
-        if self._full_data is None:
-            sub = await self.subreddit()
-            self._full_data = await self._reddit.get_request(
-                API_PATH["submission"].format(sub=sub.display_name, id=self.id))
-        return self._full_data
+        if "subreddit" in self._data and "id" in self._data:
+            resp = await self._reddit.get_request(
+                API_PATH["submission"].format(sub=self._data["subreddit"], id=self._data["id"]))
+            self._update(resp)
+        elif "id" in self._data:
+            resp = await self._reddit.get_request(API_PATH["info"],
+                                                  id=prepend_kind(self._data["id"], self._reddit.link_kind))
+            self._update(resp["data"]["children"][0]["data"])
+        return self
 
-    async def comments(self, reload=False, **kwargs) -> AsyncIterator[Comment]:
-        r"""
-        Iterate through all the comments made in the submission.
-
-        This endpoint retrieves all comments found in the full data retrieved from the /r/{sub}/comments/{id} endpoint,
-        as well as /api/morechildren. :func:`~apraw.models.Submission.morechildren` usually won't need to be called by
-        end users of aPRAW.
+    def _update(self, _data: Union[List, Dict[str, Any]]):
+        """
+        Update the base with new information.
 
         Parameters
         ----------
-        reload: bool
-            Whether to force reload the data.
-
-            .. warning::
-                ``reload`` and ``refresh`` arguments will be replaced by refreshables in future releases of aPRAW, as
-                they are alpha features.
-
-        kwargs: \*\*Dict
-            Query parameters to append to the request URL.
-
-        Yields
-        ------
-        comment: Comment
-            A comment made in the submission.
+        _data: Dict
+            The data obtained from the API.
         """
-        if len(self._comments) <= 0 or reload:
-            fd = await self.full_data()
-            self._comments = list()
+        if isinstance(_data, dict):
+            super()._update(_data)
+        elif isinstance(_data, list):
+            super()._update(_data[0]["data"]["children"][0])
 
-            for c in fd[1]["data"]["children"]:
-                if c["kind"] == self._reddit.comment_kind:
-                    self._comments.append(
-                        Comment(
-                            self._reddit,
-                            c["data"],
-                            submission=self))
-                if c["kind"] == "more":
-                    mc = [c async for c in self.morechildren(c["data"]["children"])]
-                    self._comments.extend(mc)
-        for c in self._comments:
-            yield c
-
-    async def morechildren(self, children) -> AsyncGenerator[Comment, None]:
-        """
-        Retrieves further comments made in the submission.
-
-        Parameters
-        ----------
-        children: List[str]
-            A list of comment IDs to retrieve.
-
-        Returns
-        -------
-        comments: List[Comment]
-            A list of the comments retrieved from the endpoint using their IDs.
-        """
-        while len(children) > 0:
-            cs = children[:100]
-            children = children[100:]
-
-            data = await self._reddit.get_request(API_PATH["morechildren"], children=",".join(cs), link_id=self.name)
-
-            for i in data["json"]["data"]["things"]:
-                if isinstance(i, dict) and "kind" in i and i["kind"] == self._reddit.comment_kind:
-                    yield Comment(self._reddit, i["data"], submission=self)
+            from ..helpers.listing import Listing
+            self.comments = [reply for reply in Listing(self._reddit, _data[1]["data"])]
+        else:
+            raise ValueError("data is not of type 'dict' or 'list'.")
 
 
 class SubmissionModeration(PostModeration, NSFWableMixin, SpoilerableMixin):

--- a/apraw/models/reddit/submission.py
+++ b/apraw/models/reddit/submission.py
@@ -208,7 +208,7 @@ class Submission(aPRAWBase, DeletableMixin, HideableMixin, ReplyableMixin, NSFWa
         """
         if self._full_data is None:
             sub = await self.subreddit()
-            self._full_data = await self.reddit.get_request(
+            self._full_data = await self._reddit.get_request(
                 API_PATH["submission"].format(sub=sub.display_name, id=self.id))
         return self._full_data
 
@@ -242,10 +242,10 @@ class Submission(aPRAWBase, DeletableMixin, HideableMixin, ReplyableMixin, NSFWa
             self._comments = list()
 
             for c in fd[1]["data"]["children"]:
-                if c["kind"] == self.reddit.comment_kind:
+                if c["kind"] == self._reddit.comment_kind:
                     self._comments.append(
                         Comment(
-                            self.reddit,
+                            self._reddit,
                             c["data"],
                             submission=self))
                 if c["kind"] == "more":
@@ -272,11 +272,11 @@ class Submission(aPRAWBase, DeletableMixin, HideableMixin, ReplyableMixin, NSFWa
             cs = children[:100]
             children = children[100:]
 
-            data = await self.reddit.get_request(API_PATH["morechildren"], children=",".join(cs), link_id=self.name)
+            data = await self._reddit.get_request(API_PATH["morechildren"], children=",".join(cs), link_id=self.name)
 
             for i in data["json"]["data"]["things"]:
-                if isinstance(i, dict) and "kind" in i and i["kind"] == self.reddit.comment_kind:
-                    yield Comment(self.reddit, i["data"], submission=self)
+                if isinstance(i, dict) and "kind" in i and i["kind"] == self._reddit.comment_kind:
+                    yield Comment(self._reddit, i["data"], submission=self)
 
 
 class SubmissionModeration(PostModeration, NSFWableMixin, SpoilerableMixin):

--- a/apraw/models/subreddit/moderation.py
+++ b/apraw/models/subreddit/moderation.py
@@ -68,7 +68,7 @@ class SubredditModerator(aPRAWBase):
         redditor: Redditor
             The Redditor that is represented by this object.
         """
-        return await self.reddit.redditor(self.name)
+        return await self._reddit.redditor(self.name)
 
 
 class SubredditModeration:
@@ -116,7 +116,7 @@ class SubredditModeration:
             A :class:`~apraw.models.ListingGenerator` mapped to grab reported items.
         """
         from ..helpers.generator import ListingGenerator
-        return ListingGenerator(self.subreddit.reddit,
+        return ListingGenerator(self.subreddit._reddit,
                                 API_PATH["subreddit_reports"].format(sub=self.subreddit.display_name),
                                 subreddit=self.subreddit, *args, **kwargs)
 
@@ -144,7 +144,7 @@ class SubredditModeration:
             A :class:`~apraw.models.ListingGenerator` mapped to grab items marked as spam.
         """
         from ..helpers.generator import ListingGenerator
-        return ListingGenerator(self.subreddit.reddit,
+        return ListingGenerator(self.subreddit._reddit,
                                 API_PATH["subreddit_spam"].format(sub=self.subreddit.display_name),
                                 subreddit=self.subreddit, *args, **kwargs)
 
@@ -172,7 +172,7 @@ class SubredditModeration:
             A :class:`~apraw.models.ListingGenerator` mapped to grab items in the modqueue.
         """
         from ..helpers.generator import ListingGenerator
-        return ListingGenerator(self.subreddit.reddit,
+        return ListingGenerator(self.subreddit._reddit,
                                 API_PATH["subreddit_modqueue"].format(sub=self.subreddit.display_name),
                                 subreddit=self.subreddit, *args, **kwargs)
 
@@ -200,7 +200,7 @@ class SubredditModeration:
             A :class:`~apraw.models.ListingGenerator` mapped to grab unmoderated items.
         """
         from ..helpers.generator import ListingGenerator
-        return ListingGenerator(self.subreddit.reddit,
+        return ListingGenerator(self.subreddit._reddit,
                                 API_PATH["subreddit_unmoderated"].format(sub=self.subreddit.display_name),
                                 subreddit=self.subreddit, *args, **kwargs)
 
@@ -228,7 +228,7 @@ class SubredditModeration:
             A :class:`~apraw.models.ListingGenerator` mapped to grab edited items.
         """
         from ..helpers.generator import ListingGenerator
-        return ListingGenerator(self.subreddit.reddit,
+        return ListingGenerator(self.subreddit._reddit,
                                 API_PATH["subreddit_edited"].format(sub=self.subreddit.display_name),
                                 subreddit=self.subreddit, *args, **kwargs)
 
@@ -256,7 +256,7 @@ class SubredditModeration:
             A :class:`~apraw.models.ListingGenerator` mapped to grab mod actions in the subreddit log.
         """
         from ..helpers.generator import ListingGenerator
-        return ListingGenerator(self.subreddit.reddit,
+        return ListingGenerator(self.subreddit._reddit,
                                 API_PATH["subreddit_log"].format(sub=self.subreddit.display_name),
                                 subreddit=self.subreddit, *args, **kwargs)
 
@@ -325,4 +325,4 @@ class ModAction(aPRAWBase):
         redditor: Redditor
             The Redditor who performed this action.
         """
-        return await self.subreddit.reddit.redditor(self.mod)
+        return await self.subreddit._reddit.redditor(self.mod)

--- a/apraw/models/subreddit/modmail.py
+++ b/apraw/models/subreddit/modmail.py
@@ -39,10 +39,10 @@ class SubredditModmail:
         conversation: ModmailConversation
             A modmail conversation held in the subreddit.
         """
-        req = await self.subreddit.reddit.get_request(API_PATH["modmail_conversations"],
-                                                      entity=self.subreddit.display_name)
+        req = await self.subreddit._reddit.get_request(API_PATH["modmail_conversations"],
+                                                       entity=self.subreddit.display_name)
         for id in req["conversations"]:
-            yield ModmailConversation(self.subreddit.reddit, req["conversations"][id])
+            yield ModmailConversation(self.subreddit._reddit, req["conversations"][id])
 
 
 class ModmailConversation(aPRAWBase):
@@ -114,7 +114,7 @@ class ModmailConversation(aPRAWBase):
             The subreddit this conversation was held in.
         """
         if self._owner is None:
-            self._owner = await self.reddit.subreddit(self.data["owner"]["displayName"])
+            self._owner = await self._reddit.subreddit(self._data["owner"]["displayName"])
         return self._owner
 
     async def messages(self) -> 'ModmailMessage':
@@ -140,7 +140,7 @@ class ModmailConversation(aPRAWBase):
             The full data retrieved from the endpoint.
         """
         if self._data is None:
-            self._data = await self.reddit.get_request(API_PATH["modmail_conversation"].format(id=self.id))
+            self._data = await self._reddit.get_request(API_PATH["modmail_conversation"].format(id=self.id))
         return self._data
 
 
@@ -204,7 +204,7 @@ class ModmailMessage:
         """
         if self._author is None:
             if not self.data["author"]["isDeleted"]:
-                self._author = self.conversation.reddit.redditor(  # TODO: Add 'await'
+                self._author = self.conversation._reddit.redditor(  # TODO: Add 'await'
                     self.data["author"]["name"])
             else:
                 return None

--- a/apraw/models/subreddit/subreddit.py
+++ b/apraw/models/subreddit/subreddit.py
@@ -189,7 +189,7 @@ class Subreddit(aPRAWBase):
             A random submission from the subreddit.
         """
         resp = await self._reddit.get_request(API_PATH["subreddit_random"].format(sub=self))
-        from ..helpers.listing import Listing
+        from ..reddit.listing import Listing
         listing = Listing(self._reddit, data=resp[0]["data"], subreddit=self)
         return next(listing)
 

--- a/apraw/models/subreddit/subreddit.py
+++ b/apraw/models/subreddit/subreddit.py
@@ -395,4 +395,4 @@ class Subreddit(aPRAWBase):
             "spoiler": kwargs.get("spoiler", False)
         })
 
-        return await self._reddit.submission(resp["json"]["data"]["id"])
+        return Submission(self._reddit, {"id": resp["json"]["data"]["id"]})

--- a/apraw/models/subreddit/subreddit.py
+++ b/apraw/models/subreddit/subreddit.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, AsyncIterator, Dict, Union
+from typing import TYPE_CHECKING, AsyncIterator, Dict, Union, Any
 
 from .modmail import SubredditModmail
 from .moderation import SubredditModerator, SubredditModeration
@@ -18,10 +18,6 @@ class Subreddit(aPRAWBase):
 
     Members
     -------
-    reddit: Reddit
-        The :class:`~apraw.Reddit` instance with which requests are made.
-    data: Dict
-        The data obtained from the /about endpoint.
     kind: str
         The item's kind / type.
     mod: SubredditModeration
@@ -141,7 +137,7 @@ class Subreddit(aPRAWBase):
     ================================ ==================================================================
     """
 
-    def __init__(self, reddit: 'Reddit', data: Dict):
+    def __init__(self, reddit: 'Reddit', data: Dict = None):
         """
         Create a Subreddit instance.
 
@@ -154,11 +150,34 @@ class Subreddit(aPRAWBase):
         """
         super().__init__(reddit, data, reddit.subreddit_kind)
 
-        self.quarantine = data["quarantine"] if "quarantine" in data else False
-
         self.mod = SubredditModeration(self)
         self.modmail = SubredditModmail(self)
         self.wiki = SubredditWiki(self)
+
+    async def fetch(self):
+        """
+        Fetch this item's information from a suitable API endpoint.
+
+        Returns
+        -------
+        self: Subreddit
+            The ``Subreddit`` model with updated data.
+        """
+        resp = await self._reddit.get_request(API_PATH["subreddit_about"].format(sub=self.display_name))
+        self._update(resp["data"])
+        return self
+
+    def _update(self, data: Dict[str, Any]):
+        """
+        Update the base with new information.
+
+        Parameters
+        ----------
+        data: Dict
+            The data obtained from the /about endpoint.
+        """
+        super()._update(data)
+        self.quarantine = data["quarantine"] if "quarantine" in data else False
 
     async def random(self):
         """
@@ -169,9 +188,9 @@ class Subreddit(aPRAWBase):
         submission: Submission
             A random submission from the subreddit.
         """
-        resp = await self.reddit.get_request(API_PATH["subreddit_random"].format(sub=self))
+        resp = await self._reddit.get_request(API_PATH["subreddit_random"].format(sub=self))
         from ..helpers.listing import Listing
-        listing = Listing(self.reddit, data=resp[0]["data"], subreddit=self)
+        listing = Listing(self._reddit, data=resp[0]["data"], subreddit=self)
         return next(listing)
 
     @Streamable.streamable
@@ -198,7 +217,7 @@ class Subreddit(aPRAWBase):
             A :class:`~apraw.models.ListingGenerator` mapped to the comments endpoint.
         """
         from ..helpers.generator import ListingGenerator
-        return ListingGenerator(self.reddit, API_PATH["subreddit_comments"].format(sub=self.display_name),
+        return ListingGenerator(self._reddit, API_PATH["subreddit_comments"].format(sub=self.display_name),
                                 subreddit=self, *args, **kwargs)
 
     @Streamable.streamable
@@ -225,7 +244,7 @@ class Subreddit(aPRAWBase):
             A :class:`~apraw.models.ListingGenerator` mapped to the new submissions endpoint.
         """
         from ..helpers.generator import ListingGenerator
-        return ListingGenerator(self.reddit, API_PATH["subreddit_new"].format(sub=self.display_name), subreddit=self,
+        return ListingGenerator(self._reddit, API_PATH["subreddit_new"].format(sub=self.display_name), subreddit=self,
                                 *args, **kwargs)
 
     def hot(self, *args, **kwargs):
@@ -243,7 +262,7 @@ class Subreddit(aPRAWBase):
             A :class:`~apraw.models.ListingGenerator` mapped to the hot submissions endpoint.
         """
         from ..helpers.generator import ListingGenerator
-        return ListingGenerator(self.reddit, API_PATH["subreddit_hot"].format(sub=self.display_name), subreddit=self,
+        return ListingGenerator(self._reddit, API_PATH["subreddit_hot"].format(sub=self.display_name), subreddit=self,
                                 *args, **kwargs)
 
     def rising(self, *args, **kwargs):
@@ -261,7 +280,7 @@ class Subreddit(aPRAWBase):
             A :class:`~apraw.models.ListingGenerator` mapped to the rising submissions endpoint.
         """
         from ..helpers.generator import ListingGenerator
-        return ListingGenerator(self.reddit, API_PATH["subreddit_rising"].format(sub=self.display_name), *args,
+        return ListingGenerator(self._reddit, API_PATH["subreddit_rising"].format(sub=self.display_name), *args,
                                 **kwargs)
 
     def top(self, *args, **kwargs):
@@ -279,7 +298,7 @@ class Subreddit(aPRAWBase):
             A :class:`~apraw.models.ListingGenerator` mapped to the top submissions endpoint.
         """
         from ..helpers.generator import ListingGenerator
-        return ListingGenerator(self.reddit, API_PATH["subreddit_top"].format(sub=self.display_name), subreddit=self,
+        return ListingGenerator(self._reddit, API_PATH["subreddit_top"].format(sub=self.display_name), subreddit=self,
                                 *args, **kwargs)
 
     def __str__(self):
@@ -307,9 +326,9 @@ class Subreddit(aPRAWBase):
         moderator: SubredditModerator
             An instance of the moderators as :class:`~apraw.models.SubredditModerator`.
         """
-        req = await self.reddit.get_request(API_PATH["subreddit_moderators"].format(sub=self.display_name), **kwargs)
+        req = await self._reddit.get_request(API_PATH["subreddit_moderators"].format(sub=self.display_name), **kwargs)
         for u in req["data"]["children"]:
-            yield SubredditModerator(self.reddit, u)
+            yield SubredditModerator(self._reddit, u)
 
     async def message(self, subject: str, text: str, from_sr: Union[str, 'Subreddit'] = "") -> Dict:
         """
@@ -328,8 +347,8 @@ class Subreddit(aPRAWBase):
         response: Dict
             The API response JSON as a dictionary.
         """
-        return await self.reddit.message(API_PATH["subreddit"].format(sub=self.display_name), subject, text,
-                                         str(from_sr))
+        return await self._reddit.message(API_PATH["subreddit"].format(sub=self.display_name), subject, text,
+                                          str(from_sr))
 
     async def submit(self, title: str, kind: 'SubmissionKind', **kwargs) -> 'Submission':
         """
@@ -365,7 +384,7 @@ class Subreddit(aPRAWBase):
         if kind == SubmissionKind.SELF and not text:
             raise ValueError("A text body was expected")
 
-        resp = await self.reddit.post_request(API_PATH["submit"], **{
+        resp = await self._reddit.post_request(API_PATH["submit"], **{
             "sr": str(self),
             "title": title,
             "kind": kind.value,
@@ -376,4 +395,4 @@ class Subreddit(aPRAWBase):
             "spoiler": kwargs.get("spoiler", False)
         })
 
-        return await self.reddit.submission(resp["json"]["data"]["id"])
+        return await self._reddit.submission(resp["json"]["data"]["id"])

--- a/apraw/models/subreddit/wiki.py
+++ b/apraw/models/subreddit/wiki.py
@@ -40,12 +40,12 @@ class SubredditWiki:
             A :class:`~apraw.models.ListingGenerator` mapped to recent wikipage revisions.
         """
         from ..helpers.generator import ListingGenerator
-        return ListingGenerator(self.subreddit.reddit, API_PATH["wiki_revisions"].format(sub=self.subreddit), *args,
+        return ListingGenerator(self.subreddit._reddit, API_PATH["wiki_revisions"].format(sub=self.subreddit), *args,
                                 **kwargs)
 
     async def data(self, refresh=False) -> Dict:
         if self._data is None:
-            self._data = await self.subreddit.reddit.get_request(
+            self._data = await self.subreddit._reddit.get_request(
                 API_PATH["wiki"].format(sub=self.subreddit))
         return self._data
 
@@ -54,12 +54,12 @@ class SubredditWiki:
         return [page for page in data["data"]]
 
     async def page(self, page: str) -> 'SubredditWikipage':
-        resp = await self.subreddit.reddit.get_request(
+        resp = await self.subreddit._reddit.get_request(
             API_PATH["wiki_page"].format(sub=self.subreddit, page=page))
         return SubredditWikipage(page, self.subreddit, resp["data"])
 
     async def create(self, page: str, content_md: str = "", reason: str = "") -> 'SubredditWikipage':
-        resp = await self.subreddit.reddit.post_request(
+        resp = await self.subreddit._reddit.post_request(
             API_PATH["wiki_edit"].format(sub=self.subreddit), data={
                 "page": page,
                 "content": content_md,
@@ -71,7 +71,7 @@ class SubredditWiki:
 class SubredditWikipage(aPRAWBase):
 
     def __init__(self, name: str, subreddit: 'Subreddit', data: Dict = None):
-        super().__init__(subreddit.reddit, data, subreddit.reddit.wikipage_kind)
+        super().__init__(subreddit._reddit, data, subreddit._reddit.wikipage_kind)
 
         self.name = name
         self.subreddit = subreddit
@@ -100,11 +100,11 @@ class SubredditWikipage(aPRAWBase):
             A :class:`~apraw.models.ListingGenerator` mapped to fetch specific wikipage revisions.
         """
         from ..helpers.generator import ListingGenerator
-        return ListingGenerator(self.subreddit.reddit, API_PATH["wiki_page_revisions"].format(
+        return ListingGenerator(self.subreddit._reddit, API_PATH["wiki_page_revisions"].format(
             sub=self.subreddit, page=self.name), *args, **kwargs)
 
     async def _alloweditor(self, username: str, act: str):
-        resp = await self.subreddit.reddit.post_request(
+        resp = await self.subreddit._reddit.post_request(
             API_PATH["wiki_alloweditor"].format(sub=self.subreddit, act=act), data={
                 "page": self.name,
                 "username": username
@@ -118,7 +118,7 @@ class SubredditWikipage(aPRAWBase):
         return await self._alloweditor(username, "del")
 
     async def edit(self, content_md: str = "", reason: str = "") -> bool:
-        resp = await self.subreddit.reddit.post_request(
+        resp = await self.subreddit._reddit.post_request(
             API_PATH["wiki_edit"].format(sub=self.subreddit), data={
                 "page": self.name,
                 "content": content_md,
@@ -127,7 +127,7 @@ class SubredditWikipage(aPRAWBase):
         return resp if resp else True
 
     async def hide(self, revision: Union[str, 'WikipageRevision']):
-        resp = await self.subreddit.reddit.post_request(
+        resp = await self.subreddit._reddit.post_request(
             API_PATH["wiki_hide"].format(sub=self.subreddit), data={
                 "page": self.name,
                 "revision": str(revision)
@@ -135,7 +135,7 @@ class SubredditWikipage(aPRAWBase):
         return resp if resp else True
 
     async def revert(self, revision: Union[str, 'WikipageRevision']):
-        resp = await self.subreddit.reddit.post_request(
+        resp = await self.subreddit._reddit.post_request(
             API_PATH["wiki_revert"].format(sub=self.subreddit), data={
                 "page": self.name,
                 "revision": str(revision)

--- a/apraw/models/user.py
+++ b/apraw/models/user.py
@@ -249,4 +249,4 @@ class Karma(aPRAWBase):
         subreddit: Subreddit
             The subreddit on which the karma was obtained.
         """
-        return await self.reddit.subreddit(self.sr)
+        return await self._reddit.subreddit(self.sr)

--- a/apraw/reddit.py
+++ b/apraw/reddit.py
@@ -172,12 +172,7 @@ class Reddit:
         result: None
             Returns None if subreddit not found.
         """
-        resp = await self.get_request(API_PATH["subreddit_about"].format(sub=display_name))
-        try:
-            return Subreddit(self, resp["data"])
-        except Exception as e:
-            logging.error(e)
-            return None
+        return await Subreddit(self, {"display_name": display_name}).fetch()
 
     async def info(self, id: str = "", ids: List[str] = [], url: str = ""):
         """

--- a/apraw/reddit.py
+++ b/apraw/reddit.py
@@ -249,12 +249,9 @@ class Reddit:
             The requested comment.
         """
         if id != "":
-            async for comment in self.info(prepend_kind(id, self.comment_kind)):
-                return comment
-        elif url != "":
-            async for comment in self.info(url=url):
-                return comment
-        return None
+            return await Comment(self, {"id": id}).fetch()
+        else:
+            return await Comment(self, {"url": url}).fetch()
 
     async def redditor(self, username: str) -> Redditor:
         """
@@ -270,12 +267,7 @@ class Reddit:
         redditor: Redditor or None
             The requested Redditor, returns None if not found.
         """
-        resp = await self.get_request(API_PATH["user_about"].format(user=username))
-        try:
-            return Redditor(self, resp["data"])
-        except Exception as e:
-            # print("No Redditor data loaded for {}.".format(username))
-            return None
+        return await Redditor(self, {"username": username}).fetch()
 
     async def message(self, to: Union[str, Redditor], subject: str, text: str,
                       from_sr: Union[str, Subreddit] = "") -> Dict:

--- a/tests/integration/models/test_comment.py
+++ b/tests/integration/models/test_comment.py
@@ -26,9 +26,9 @@ class TestComment:
     async def test_comment_replies(self, reddit):
         comment = await reddit.comment("fulsybg")
 
-        async def scan_comments(c):
-            async for reply in c.replies():
+        def scan_comments(c):
+            for reply in c.replies:
                 assert isinstance(reply, apraw.models.Comment)
-                await scan_comments(reply)
+                scan_comments(reply)
 
-        await scan_comments(comment)
+        scan_comments(comment)

--- a/tests/integration/models/test_submission.py
+++ b/tests/integration/models/test_submission.py
@@ -5,33 +5,18 @@ import apraw
 
 class TestSubmission:
     @pytest.mark.asyncio
-    async def test_submission_full_data(self, reddit):
-        submission = await reddit.submission("h7mna9")
-        full_data = await submission.full_data()
-        assert full_data[0]["data"]["children"][0]["data"]["id"] == "h7mna9"
-
-    @pytest.mark.asyncio
     async def test_submission_comments(self, reddit):
         submission = await reddit.submission("h7mna9")
         comment_found = False
 
-        async for comment in submission.comments():
+        await submission.fetch()
+
+        for comment in submission.comments:
             if comment.id == "fulsybg":
                 comment_found = True
                 break
 
         assert comment_found
-
-    @pytest.mark.asyncio
-    async def test_submission_morechildren(self, reddit):
-        submission = await reddit.submission("h7mna9")
-        children = []
-
-        async for comment in submission.comments():
-            children.append(comment.id)
-
-        async for comment in submission.morechildren(children):
-            assert isinstance(comment, apraw.models.Comment)
 
     @pytest.mark.asyncio
     async def test_submission_subreddit(self, reddit):

--- a/tests/integration/models/test_submission_moderation.py
+++ b/tests/integration/models/test_submission_moderation.py
@@ -55,9 +55,9 @@ class TestSubmissionModeration:
         await submission.mod.spoiler()
         submission = await reddit.submission("h7mna9")
 
-        assert submission.data["spoiler"]
+        assert submission._data["spoiler"]
 
         await submission.mod.unspoiler()
         submission = await reddit.submission("h7mna9")
 
-        assert not submission.data["spoiler"]
+        assert not submission._data["spoiler"]


### PR DESCRIPTION
Closes #78 

## Feature Summary
> Explain what's new in this pull request.

 - Refactor `class aPRAWBase` members `reddit` and `data` to `_reddit` and `_data`.
 - aPRAWBase models can be loaded without all the endpoint information.
    - Lazy objects are returned by methods such as `Subreddit.submit()`.
 - `aPRAWBase.fetch()` implemented in most models to fetch extra data.
 - Update `Comment.replies()` and `Submission.comments()` to attributes as lists.
 - Implement `aPRAWBase.__repr__()` returning string in format of `<{class} {id_attribute}='{id}'>`.

## Tests

 - Updated tests for `Comment.replies()` and `Submission.comments()`.
 - Removed `test_submission_morechildren` and `test_submission_morechildren`.