### PR TITLE
Reactive Comments, Fix Stream

### DIFF
--- a/apraw/models/helpers/apraw_base.py
+++ b/apraw/models/helpers/apraw_base.py
@@ -34,6 +34,8 @@ class aPRAWBase:
             The data obtained from the /about endpoint.
         """
         self._reddit = reddit
+        self._data = data
+        self._data_attrs = set()
         self.kind = kind
 
         if data:
@@ -53,6 +55,9 @@ class aPRAWBase:
         d = snake_case_keys(data)
         for key in d:
             if not hasattr(self, key):
+                self._data_attrs.add(key)
+                setattr(self, key, d[key])
+            elif key in self._data_attrs:
                 setattr(self, key, d[key])
 
         if "created_utc" in data:

--- a/apraw/models/helpers/streamable.py
+++ b/apraw/models/helpers/streamable.py
@@ -100,26 +100,23 @@ class Streamable:
         counter = ExponentialCounter(self.max_wait)
         seen_attributes = list()
 
-        if skip_existing:
-            items = [i async for i in self(1, *args, **kwargs)]
-            for item in reversed(items):
-                seen_attributes.append(getattr(item, self.attribute_name))
-                break
-
         while True:
             found = False
             items = [i async for i in self(100, *args, **kwargs)]
             for item in reversed(items):
                 attribute = getattr(item, self.attribute_name)
-
                 if attribute in seen_attributes:
-                    break
+                    continue
+
                 if len(seen_attributes) >= 301:
                     seen_attributes = seen_attributes[1:]
 
                 seen_attributes.append(attribute)
                 found = True
-                yield item
+                if not skip_existing:
+                    yield item
+
+            skip_existing = False
 
             if found:
                 wait = counter.reset()

--- a/apraw/models/helpers/streamable.py
+++ b/apraw/models/helpers/streamable.py
@@ -3,7 +3,7 @@ from functools import update_wrapper
 from typing import AsyncIterator, Callable, Any, Union, AsyncGenerator, Generator, Iterator, Awaitable
 
 from .apraw_base import aPRAWBase
-from ...utils.counter import ExponentialCounter
+from ...utils import ExponentialCounter
 
 # I know, I know, this code is cursed
 SYNC_OR_ASYNC_ITERABLE = Union[

--- a/apraw/utils/__init__.py
+++ b/apraw/utils/__init__.py
@@ -1,2 +1,3 @@
 from .snake import snake_case_keys
 from .kind import prepend_kind
+from .counter import ExponentialCounter

--- a/apraw/utils/counter.py
+++ b/apraw/utils/counter.py
@@ -1,4 +1,4 @@
-from random import random
+import random
 
 
 class ExponentialCounter:
@@ -26,8 +26,8 @@ class ExponentialCounter:
             The current value defined by the counter.
         """
         max_jitter = self._value / 16.0
-        value = self._value + random.random() * max_jitter - max_jitter / 2
         self._value = min(self._value * 2, self._max)
+        value = self._value + random.random() * max_jitter - max_jitter / 2
         if self._value >= self._max:
             self._value = 1
         return value

--- a/apraw/utils/counter.py
+++ b/apraw/utils/counter.py
@@ -1,0 +1,45 @@
+from random import random
+
+
+class ExponentialCounter:
+    """A class to provide an exponential counter with jitter."""
+
+    def __init__(self, max_counter: int):
+        """
+        Initialize an instance of ExponentialCounter.
+
+        Parameters
+        ----------
+        max_counter: int
+            The maximum value to reach before resetting.
+        """
+        self._value = 1
+        self._max = max_counter
+
+    def count(self) -> int:
+        """
+        Increment the counter and return the current value with jitter.
+
+        Returns
+        -------
+        value: int
+            The current value defined by the counter.
+        """
+        max_jitter = self._value / 16.0
+        value = self._value + random.random() * max_jitter - max_jitter / 2
+        self._value = min(self._value * 2, self._max)
+        if self._value >= self._max:
+            self._value = 1
+        return value
+
+    def reset(self):
+        """
+        Reset the counter to 1.
+
+        Returns
+        -------
+        value: int
+            The reset value for easy use.
+        """
+        self._value = 1
+        return self._value

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 aiohttp>=3.6.2
 pytest>=5.4.3
 pytest-asyncio>=0.12.0
+reactivepy>=1.8.2.dev0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 aiohttp>=3.6.2
 pytest>=5.4.3
-pytest-asyncio>=0.12.0
-reactivepy>=1.8.2.dev0
+pytest-asyncio>=0.14.0
+reactivepy>=1.9.0.dev0

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,8 @@ setuptools.setup(
     url="https://github.com/Dan6erbond/aPRAW",
     packages=setuptools.find_packages(include=['apraw', 'apraw.*']),
     install_requires=[
-        'aiohttp>=3.6.2'
+        'aiohttp>=3.6.2',
+        'reactivepy>=1.9.0.dev0'
     ],
     keywords="reddit api wrapper async",
     classifiers=[

--- a/tests/integration/models/test_comment.py
+++ b/tests/integration/models/test_comment.py
@@ -11,6 +11,12 @@ class TestComment:
         assert author.name == "Dan6erbond"
 
     @pytest.mark.asyncio
+    async def test_comment_fetch(self, reddit):
+        comment = await reddit.comment("fulsybg")
+        assert isinstance(await comment.fetch(), bool)
+        assert isinstance(await comment.fetch(), bool)
+
+    @pytest.mark.asyncio
     async def test_comment_submission(self, reddit):
         comment = await reddit.comment("fulsybg")
         submission = await comment.submission()


### PR DESCRIPTION
Closes #81
Partially addresses #79 

## Feature Summary
> Explain what's new in this pull request.

**ReactivePy:**

 - Add ReactivePy v1.9.0.dev0 as a requirement.
 - Initialize `_data` and `_data_attrs` in `class aPRAWBase` to keep track of modifiable attributes.
 - Make `class Comment` inherit from `class ReactiveOwner` and use `@all_reactive` decorator.
 - Update `Comment.fetch()` to return boolean result of `_bulk_update()`.
 - Add `Comment.monitor()` using `class ExponentialCounter` and `fetch()` result to poll data.

**Other:**

 - Fix `class Streamable` skipping all new items.
 - Fix use of `random.random()` in `class ExponentialCounter`.
 - Export `class ExponentialCounter` in `apraw.utils`.
 - Make `User.get_auth_session()` and `get_client_session()` auto-properties.
 - Add `close()` to `class Reddit`, `class RequestHandler` and `class User` to close open sessions.
    - Use `Reddit.close()` as shorthand.

## Tests Added
> Describe tests if any were written.

 - Add `test_comment_fetch()`.