### PR TITLE
CommentForrest and MoreComments

### DIFF
--- a/apraw/models/__init__.py
+++ b/apraw/models/__init__.py
@@ -5,6 +5,7 @@ from .helpers.streamable import Streamable
 from .reddit.comment import Comment
 from .reddit.listing import Listing
 from .reddit.message import Message
+from .reddit.more_comments import MoreComments
 from .reddit.redditor import Redditor
 from .reddit.submission import Submission
 from .subreddit.moderation import ModAction

--- a/apraw/models/helpers/comment_forrest.py
+++ b/apraw/models/helpers/comment_forrest.py
@@ -1,0 +1,32 @@
+from typing import TYPE_CHECKING, Dict
+
+from ..reddit.comment import Comment
+from ..reddit.listing import Listing
+from ..reddit.more_comments import MoreComments
+from ..subreddit.subreddit import Subreddit
+
+if TYPE_CHECKING:
+    from ...reddit import Reddit
+
+
+class CommentForrest(Listing):
+
+    def __init__(self, reddit: 'Reddit', data: Dict, link_id: str, subreddit: Subreddit = None):
+        super().__init__(reddit, data, subreddit, link_id=link_id)
+        self._comments_unfolded = []
+
+    async def replace_more(self):
+        if not self._comments_unfolded:
+            for item in self:
+                if isinstance(item, MoreComments):
+                    comments = await item.comments()
+                    for comment in comments:
+                        if comment.replies:
+                            await comment.replies.replace_more()
+                    self._comments_unfolded.extend(comments)
+                elif isinstance(item, Comment):
+                    if item.replies:
+                        await item.replies.replace_more()
+                    self._comments_unfolded.append(item)
+
+            setattr(self, self.CHILD_ATTRIBUTE, self._comments_unfolded)

--- a/apraw/models/reddit/comment.py
+++ b/apraw/models/reddit/comment.py
@@ -21,9 +21,10 @@ from ...utils import prepend_kind, snake_case_keys, ExponentialCounter
 if TYPE_CHECKING:
     from ...reddit import Reddit
     from .submission import Submission
+    from ..helpers.comment_forrest import CommentForrest
 
 
-@all_reactive(not_type=(aPRAWBase, datetime))
+@all_reactive(not_type=(aPRAWBase, datetime, PostModeration))
 class Comment(aPRAWBase, DeletableMixin, HideableMixin, ReplyableMixin, SavableMixin, VotableMixin, AuthorMixin,
               SubredditMixin, ReactiveOwner):
     """
@@ -125,7 +126,7 @@ class Comment(aPRAWBase, DeletableMixin, HideableMixin, ReplyableMixin, SavableM
     """
 
     def __init__(self, reddit: 'Reddit', data: Dict, submission: 'Submission' = None,
-                 author: Redditor = None, subreddit: Subreddit = None, replies: List['Comment'] = None):
+                 author: Redditor = None, subreddit: Subreddit = None, replies: Union['CommentForrest', List] = None):
         """
         Create an instance of a comment.
 
@@ -144,14 +145,15 @@ class Comment(aPRAWBase, DeletableMixin, HideableMixin, ReplyableMixin, SavableM
         replies: List[Comment]
             A list of replies made to this comment.
         """
+        self.replies = replies if replies else []
+
         ReactiveOwner.__init__(self)
         aPRAWBase.__init__(self, reddit, data, reddit.comment_kind)
         AuthorMixin.__init__(self, author)
         SubredditMixin.__init__(self, subreddit)
 
-        self.mod = CommentModeration(reddit, self)
         self._submission = submission
-        self.replies = replies if replies else []
+        self.mod = CommentModeration(reddit, self)
 
     async def fetch(self):
         """
@@ -162,14 +164,13 @@ class Comment(aPRAWBase, DeletableMixin, HideableMixin, ReplyableMixin, SavableM
         self: Comment
             The ``Comment`` model with updated data.
         """
-        if "permalink" in self._data:
-            resp = await self._reddit.get_request(self._data["permalink"])
-            return self._update(resp[1]["data"]["children"][0]["data"])
-        elif "link_id" in self._data and "id" in self._data and "subreddit" in self._data:
-            permalink = API_PATH["comment"].format(sub=self._data["subreddit"],
-                                                   submission=self._data["link_id"].replace(
-                                                       self._reddit.link_kind + "_", ""), id=self._data["id"])
+        if ("link_id" in self._data and "id" in self._data and "subreddit" in self._data) or "permalink" in self._data:
+            permalink = self._data["permalink"] if "permalink" in self._data else API_PATH["comment"].format(
+                sub=self._data["subreddit"], submission=self._data["link_id"].replace(self._reddit.link_kind + "_", ""),
+                id=self._data["id"])
             resp = await self._reddit.get_request(permalink)
+            from .submission import Submission
+            self._submission = Submission(self._reddit, resp[0]["data"]["children"][0]["data"])
             return self._update(resp[1]["data"]["children"][0]["data"])
         elif "id" in self._data:
             resp = await self._reddit.get_request(API_PATH["info"],
@@ -199,12 +200,10 @@ class Comment(aPRAWBase, DeletableMixin, HideableMixin, ReplyableMixin, SavableM
         """
 
         if isinstance(_data, dict) or isinstance(_data, list):
-            if isinstance(_data, dict):
-                data = _data
-            else:
-                data = _data[0]["data"]
-                from .listing import Listing
-                self.replies = [reply for reply in Listing(self._reddit, _data[1]["data"])]
+            data = _data if isinstance(_data, dict) else _data[0]["data"]
+            if isinstance(_data, list):
+                from ..helpers.comment_forrest import CommentForrest
+                self.replies = CommentForrest(self._reddit, _data[1]["data"], data["link_id"])
 
             self._data = data
 

--- a/apraw/models/reddit/listing.py
+++ b/apraw/models/reddit/listing.py
@@ -2,6 +2,7 @@ from typing import TYPE_CHECKING, Dict, Iterator, List
 
 from .comment import Comment
 from .message import Message
+from .more_comments import MoreComments
 from .submission import Submission
 from ..helpers.apraw_base import aPRAWBase
 from ..subreddit.moderation import ModAction
@@ -33,7 +34,7 @@ class Listing(aPRAWBase, Iterator):
     CHILD_ATTRIBUTE = "children"
 
     def __init__(self, reddit: 'Reddit', data: Dict, kind_filter: List[str] = None,
-                 subreddit: Subreddit = None):
+                 subreddit: Subreddit = None, link_id: str = ""):
         """
         Create a ``Listing`` instance.
 
@@ -52,6 +53,7 @@ class Listing(aPRAWBase, Iterator):
 
         self._index = 0
         self._subreddit = subreddit
+        self._link_id = link_id
         self._kind_filter = kind_filter if kind_filter else []
 
     def __len__(self) -> int:
@@ -91,7 +93,7 @@ class Listing(aPRAWBase, Iterator):
             self._index += 1
             item = self[self._index - 1]
 
-            if not self._kind_filter or self._kind_filter and item.kind in self._kind_filter:
+            if not self._kind_filter or (self._kind_filter and item.kind in self._kind_filter):
                 break
 
         return item
@@ -110,28 +112,34 @@ class Listing(aPRAWBase, Iterator):
         item: aPRAWBase
             The searched item.
         """
-        data = getattr(self, self.CHILD_ATTRIBUTE)[index]
+        item = getattr(self, self.CHILD_ATTRIBUTE)[index]
 
-        if "page" in data:
-            return WikipageRevision(self._reddit, data)
-        elif data["kind"] == self._reddit.link_kind:
-            return Submission(self._reddit, data["data"], subreddit=self._subreddit)
-        elif data["kind"] == self._reddit.subreddit_kind:
-            return Subreddit(self._reddit, data["data"])
-        elif data["kind"] == self._reddit.comment_kind:
-            if data["data"]["replies"] and data["data"]["replies"]["kind"] == self._reddit.listing_kind:
-                replies = [reply for reply in Listing(self._reddit, data["data"]["replies"]["data"])]
+        if isinstance(item, aPRAWBase):
+            return item
+
+        if "page" in item:
+            return WikipageRevision(self._reddit, item)
+        elif item["kind"] == self._reddit.link_kind:
+            return Submission(self._reddit, item["data"], subreddit=self._subreddit)
+        elif item["kind"] == self._reddit.subreddit_kind:
+            return Subreddit(self._reddit, item["data"])
+        elif item["kind"] == self._reddit.comment_kind:
+            if item["data"]["replies"] and item["data"]["replies"]["kind"] == self._reddit.listing_kind:
+                from ..helpers.comment_forrest import CommentForrest
+                replies = CommentForrest(self._reddit, item["data"]["replies"]["data"], item["data"]["link_id"])
             else:
                 replies = []
-            return Comment(self._reddit, data["data"], subreddit=self._subreddit, replies=replies)
-        elif data["kind"] == self._reddit.modaction_kind:
-            return ModAction(self._reddit, data["data"], self._subreddit)
-        elif data["kind"] == self._reddit.message_kind:
-            return Message(self._reddit, data["data"])
-        elif data["kind"] == self._reddit.listing_kind:
-            return Listing(self._reddit, data["data"])
+            return Comment(self._reddit, item["data"], subreddit=self._subreddit, replies=replies)
+        elif item["kind"] == self._reddit.modaction_kind:
+            return ModAction(self._reddit, item["data"], self._subreddit)
+        elif item["kind"] == self._reddit.message_kind:
+            return Message(self._reddit, item["data"])
+        elif item["kind"] == self._reddit.listing_kind:
+            return Listing(self._reddit, item["data"])
+        elif item["kind"] == self._reddit.more_kind:
+            return MoreComments(self._reddit, item["data"], self._link_id)
         else:
-            return aPRAWBase(self._reddit, data["data"] if "data" in data else data)
+            return aPRAWBase(self._reddit, item["data"] if "data" in item else item)
 
     @property
     def last(self) -> aPRAWBase:
@@ -144,3 +152,7 @@ class Listing(aPRAWBase, Iterator):
             The last item in the listing.
         """
         return self[len(self) - 1] if len(self) > 0 else None
+
+
+class MoreChildren(Listing):
+    CHILD_ATTRIBUTE = "things"

--- a/apraw/models/reddit/more_comments.py
+++ b/apraw/models/reddit/more_comments.py
@@ -1,0 +1,61 @@
+from typing import TYPE_CHECKING, Dict, Any, List, Union
+
+from .comment import Comment
+from .submission import Submission
+from ..helpers.apraw_base import aPRAWBase
+from ...const import API_PATH
+
+if TYPE_CHECKING:
+    from ...reddit import Reddit
+
+
+class MoreComments(aPRAWBase):
+
+    def __init__(self, reddit: 'Reddit', data: Dict[str, Any], link_id: str):
+        data.update(link_id=link_id)
+        super().__init__(reddit, data)
+
+        self._comments = []
+        self._ids = list(self.children)
+        self._index = 0
+
+    async def _next_batch(self):
+        if not self._ids:
+            return
+
+        ids = self._ids[:100]
+        self._ids = self._ids[100:]
+        resp = await self._reddit.get_request(API_PATH["morechildren"], **{
+            "children": ",".join(ids),
+            "link_id": self.link_id,
+            "id": self.id,
+            "depth": self.depth
+        })
+
+        from .listing import MoreChildren
+        children = MoreChildren(self._reddit, resp["json"]["data"], [self._reddit.comment_kind, self._reddit.more_kind],
+                                self.link_id)
+        self._comments.extend(comment for comment in children)
+
+    async def parent(self) -> Union[Submission, Comment]:
+        return await self._reddit.info(self.parent_id)
+
+    async def fetch(self):
+        while self._ids:
+            await self._next_batch()
+
+    async def __anext__(self) -> Comment:
+        if self._index >= len(self._comments) and not self._ids:
+            raise StopAsyncIteration
+
+        if not self._comments or self._ids:
+            await self._next_batch()
+
+        self._index += 1
+        return self._comments[self._index + 1]
+
+    async def comments(self) -> List[Comment]:
+        if not self._comments:
+            await self.fetch()
+
+        return self._comments

--- a/apraw/models/subreddit/subreddit.py
+++ b/apraw/models/subreddit/subreddit.py
@@ -395,4 +395,7 @@ class Subreddit(aPRAWBase):
             "spoiler": kwargs.get("spoiler", False)
         })
 
-        return Submission(self._reddit, {"id": resp["json"]["data"]["id"]})
+        submission = Submission(self._reddit, {"id": resp["json"]["data"]["id"]})
+        await submission.fetch()
+
+        return submission

--- a/apraw/models/user.py
+++ b/apraw/models/user.py
@@ -98,8 +98,7 @@ class User:
         self.ratelimit_used = 0
         self.ratelimit_reset = datetime.now()
 
-    @property
-    def auth_session(self) -> aiohttp.ClientSession:
+    async def auth_session(self) -> aiohttp.ClientSession:
         """
         Retrieve an ``aiohttp.ClientSesssion`` with which the authentication token can be obtained.
 
@@ -112,11 +111,10 @@ class User:
             auth = aiohttp.BasicAuth(
                 login=self.client_id,
                 password=self.client_secret)
-            self._auth_session = aiohttp.ClientSession(auth=auth, loop=self.reddit.loop)
+            self._auth_session = aiohttp.ClientSession(auth=auth)
         return self._auth_session
 
-    @property
-    def client_session(self) -> aiohttp.ClientSession:
+    async def client_session(self) -> aiohttp.ClientSession:
         """
         Retrieve the ``aiohttp.ClientSesssion`` with which regular requests are made.
 
@@ -126,7 +124,7 @@ class User:
             The session with which requests should be made.
         """
         if self._client_session is None:
-            self._client_session = aiohttp.ClientSession(loop=self.reddit.loop)
+            self._client_session = aiohttp.ClientSession()
         return self._client_session
 
     async def close(self):

--- a/requests/dumps/morecomments.json
+++ b/requests/dumps/morecomments.json
@@ -1,0 +1,13 @@
+{
+  "kind": "more",
+  "data": {
+    "count": 1,
+    "name": "t1_fv01koe",
+    "id": "fv01koe",
+    "parent_id": "t1_fultzez",
+    "depth": 2,
+    "children": [
+      "fv01koe"
+    ]
+  }
+}

--- a/tests/integration/models/test_comment_forrest.py
+++ b/tests/integration/models/test_comment_forrest.py
@@ -1,0 +1,21 @@
+import pytest
+
+import apraw
+from apraw import Reddit
+
+
+class TestCommentForrest:
+    @pytest.mark.asyncio
+    async def test_comment_forrest_replace_more(self, reddit: Reddit):
+        submission = await reddit.submission("hneroz")
+
+        await submission.fetch()
+
+        if submission.comments:
+            original = len(submission.comments)
+            await submission.comments.replace_more()
+
+            for comment in submission.comments:
+                assert not isinstance(comment, apraw.models.MoreComments)
+
+            assert len(submission.comments) >= original

--- a/tests/integration/test_reddit.py
+++ b/tests/integration/test_reddit.py
@@ -16,8 +16,8 @@ class TestReddit:
 
     @pytest.mark.asyncio
     async def test_reddit_comment(self, reddit: apraw.Reddit):
-        comment = await reddit.comment("fulsybg")
-        assert comment.body == "This is a test comment."
+        comment = await reddit.comment("fuoew5r")
+        assert comment.body == "Test comment by bot."
 
     @pytest.mark.asyncio
     async def test_reddit_redditor(self, reddit: apraw.Reddit):


### PR DESCRIPTION
Closes #83 

## Feature Summary
> Explain what's new in this pull request.

**`class CommentForrest`:**

 - Implement based on `class Listing`.
 - Add `replace_more()` to unfold comments and overwrite old list.
 - Accept `link_id` for dependency injection.

**`class MoreComments`:**

 - ~~Implement based on `class Listing`.~~
 - Make async generator for dynamically loading next comments if more than 100 IDs are present.
 - Add `comments()` to return flattened list of `class Comment`.
 - Add `parent()` to return parent `class Comment`/`class Submission`.
 - `depth` attribute can be modified to go into deeper trees.

**Other:**

 - Implement `class MoreChildren` based on `class Listing` for `/morechildren` API responses.
 - Make `Subreddit.submit()` automatically returned fetched `class Submission` on complete.
 - Make `auth_session` and `client_session` async functions to fix issues with event-loop.

## Tests

 - Add `test_comment_forrest_replace_more` with large [/r/facepalm](https://reddit.com/r/facepalm) thread.
 - Change test comment to static bot comment to avoid edits / removals.