### PR TITLE
Bring up @streamable decorator and create ProxyStreamable using Descriptor Protocol

### DIFF
--- a/apraw/models/__init__.py
+++ b/apraw/models/__init__.py
@@ -1,7 +1,7 @@
 from .helpers.apraw_base import aPRAWBase
 from .helpers.generator import ListingGenerator
 from .helpers.item_moderation import ItemModeration, PostModeration
-from .helpers.streamable import Streamable
+from .helpers.streamable import Streamable, streamable
 from .reddit.comment import Comment
 from .reddit.listing import Listing
 from .reddit.message import Message

--- a/apraw/models/helpers/streamable.py
+++ b/apraw/models/helpers/streamable.py
@@ -12,6 +12,39 @@ SYNC_OR_ASYNC_ITERABLE = Union[
         aPRAWBase, None, None]]
 
 
+def streamable(func: SYNC_OR_ASYNC_ITERABLE = None, max_wait: int = 16, attribute_name: str = "fullname"):
+    if func:
+        return ProxyStreamable(func)
+    else:
+        def wrapper(_func: SYNC_OR_ASYNC_ITERABLE):
+            return ProxyStreamable(_func, max_wait, attribute_name)
+
+        return wrapper
+
+
+class ProxyStreamable:
+
+    def __init__(self, func: SYNC_OR_ASYNC_ITERABLE, max_wait: int = 16, attribute_name: str = "fullname"):
+        self._func = func
+        self._max_wait = max_wait
+        self._attribute_name = attribute_name
+
+    def __set_name__(self, owner: Any, name: str):
+        self._name = name
+
+    def __get__(self, instance: Any, owner: Any):
+        return instance.__dict__.setdefault(self._name,
+                                            Streamable(self._func, self._max_wait, self._attribute_name, instance))
+
+    async def __call__(self, *args, **kwargs):
+        async for i in Streamable(self._func, self._max_wait, self._attribute_name)(*args, **kwargs):
+            yield i
+
+    async def stream(self, *args, **kwargs):
+        async for i in Streamable(self._func, self._max_wait, self._attribute_name).stream(*args, **kwargs):
+            yield i
+
+
 class Streamable:
     """
     A decorator to make functions returning a generator streamable.
@@ -24,18 +57,8 @@ class Streamable:
         The attribute name to use as a unique identifier for returned objects.
     """
 
-    @classmethod
-    def streamable(cls, func: SYNC_OR_ASYNC_ITERABLE = None, max_wait: int = 16, attribute_name: str = "fullname"):
-        if func:
-            return Streamable(func)
-        else:
-            def wrapper(
-                    _func: SYNC_OR_ASYNC_ITERABLE):
-                return Streamable(_func, max_wait, attribute_name)
-
-            return wrapper
-
-    def __init__(self, func: SYNC_OR_ASYNC_ITERABLE, max_wait: int = 16, attribute_name: str = "fullname"):
+    def __init__(self, func: SYNC_OR_ASYNC_ITERABLE, max_wait: int = 16,
+                 attribute_name: str = "fullname", instance: Any = None):
         """
         Create an instance of the streamable object.
 
@@ -48,25 +71,19 @@ class Streamable:
         attribute_name: str
             The attribute name to use as a unique identifier for returned objects.
         """
+        self._instance = instance
+        self._attribute_name = attribute_name
         self._func = func
         update_wrapper(self, func)
 
         self.max_wait = max_wait
-        self.attribute_name = attribute_name
-
-    def __get__(self, instance: Any, owner: Any):
-        """
-        Allow streamable to access its top-level object instance to forward to functions later.
-        """
-        self.instance = instance
-        return self
 
     async def __call__(self, *args, **kwargs):
         """
         Make streamable callable to return result of decorated function.
         """
         if hasattr(self._func, "__call__"):
-            func_args = (self.instance, *args) if hasattr(self, "instance") else args
+            func_args = (self._instance, *args) if self._instance else args
             if asyncio.iscoroutinefunction(self._func):
                 iterable = await self._func(*func_args, **kwargs)
             else:
@@ -104,7 +121,7 @@ class Streamable:
             found = False
             items = [i async for i in self(100, *args, **kwargs)]
             for item in reversed(items):
-                attribute = getattr(item, self.attribute_name)
+                attribute = getattr(item, self._attribute_name)
                 if attribute in seen_attributes:
                     continue
 

--- a/apraw/models/reddit/redditor.py
+++ b/apraw/models/reddit/redditor.py
@@ -1,7 +1,7 @@
 from typing import TYPE_CHECKING, Dict
 
 from ..helpers.apraw_base import aPRAWBase
-from ..helpers.streamable import Streamable
+from ..helpers.streamable import streamable
 from ...const import API_PATH
 
 if TYPE_CHECKING:
@@ -96,7 +96,7 @@ class Redditor(aPRAWBase):
         self._update(resp["data"])
         return self
 
-    @Streamable.streamable
+    @streamable
     def comments(self, *args, **kwargs):
         r"""
         Returns an instance of :class:`~apraw.models.ListingGenerator` mapped to fetch the Redditor's comments.
@@ -122,7 +122,7 @@ class Redditor(aPRAWBase):
         from ..helpers.generator import ListingGenerator
         return ListingGenerator(self.reddit, API_PATH["user_comments"].format(user=self), *args, **kwargs)
 
-    @Streamable.streamable
+    @streamable
     def submissions(self, *args, **kwargs):
         r"""
         Returns an instance of :class:`~apraw.models.ListingGenerator` mapped to fetch the Redditor's submissions.

--- a/apraw/models/subreddit/moderation.py
+++ b/apraw/models/subreddit/moderation.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from typing import Dict, TYPE_CHECKING
 
 from ..helpers.apraw_base import aPRAWBase
-from ..helpers.streamable import Streamable
+from ..helpers.streamable import streamable
 from ..reddit.redditor import Redditor
 from ...const import API_PATH
 
@@ -92,7 +92,7 @@ class SubredditModeration:
         """
         self.subreddit = subreddit
 
-    @Streamable.streamable
+    @streamable
     def reports(self, *args, **kwargs):
         r"""
         Returns an instance of :class:`~apraw.models.ListingGenerator` mapped to grab reported items.
@@ -120,7 +120,7 @@ class SubredditModeration:
                                 API_PATH["subreddit_reports"].format(sub=self.subreddit.display_name),
                                 subreddit=self.subreddit, *args, **kwargs)
 
-    @Streamable.streamable
+    @streamable
     def spam(self, *args, **kwargs):
         r"""
         Returns an instance of :class:`~apraw.models.ListingGenerator` mapped to grab items marked as spam.
@@ -148,7 +148,7 @@ class SubredditModeration:
                                 API_PATH["subreddit_spam"].format(sub=self.subreddit.display_name),
                                 subreddit=self.subreddit, *args, **kwargs)
 
-    @Streamable.streamable
+    @streamable
     def modqueue(self, *args, **kwargs):
         r"""
         Returns an instance of :class:`~apraw.models.ListingGenerator` mapped to grab items in the modqueue.
@@ -176,7 +176,7 @@ class SubredditModeration:
                                 API_PATH["subreddit_modqueue"].format(sub=self.subreddit.display_name),
                                 subreddit=self.subreddit, *args, **kwargs)
 
-    @Streamable.streamable
+    @streamable
     def unmoderated(self, *args, **kwargs):
         r"""
         Returns an instance of :class:`~apraw.models.ListingGenerator` mapped to grab unmoderated items.
@@ -204,7 +204,7 @@ class SubredditModeration:
                                 API_PATH["subreddit_unmoderated"].format(sub=self.subreddit.display_name),
                                 subreddit=self.subreddit, *args, **kwargs)
 
-    @Streamable.streamable
+    @streamable
     def edited(self, *args, **kwargs):
         r"""
         Returns an instance of :class:`~apraw.models.ListingGenerator` mapped to grab edited items.
@@ -232,7 +232,7 @@ class SubredditModeration:
                                 API_PATH["subreddit_edited"].format(sub=self.subreddit.display_name),
                                 subreddit=self.subreddit, *args, **kwargs)
 
-    @Streamable.streamable
+    @streamable
     def log(self, *args, **kwargs):
         r"""
         Returns an instance of :class:`~apraw.models.ListingGenerator` mapped to grab mod actions in the subreddit log.

--- a/apraw/models/subreddit/subreddit.py
+++ b/apraw/models/subreddit/subreddit.py
@@ -1,10 +1,10 @@
 from typing import TYPE_CHECKING, AsyncIterator, Dict, Union, Any
 
-from .modmail import SubredditModmail
 from .moderation import SubredditModerator, SubredditModeration
+from .modmail import SubredditModmail
 from .wiki import SubredditWiki
 from ..helpers.apraw_base import aPRAWBase
-from ..helpers.streamable import Streamable
+from ..helpers.streamable import Streamable, streamable
 from ...const import API_PATH
 
 if TYPE_CHECKING:
@@ -193,7 +193,7 @@ class Subreddit(aPRAWBase):
         listing = Listing(self._reddit, data=resp[0]["data"], subreddit=self)
         return next(listing)
 
-    @Streamable.streamable
+    @streamable
     def comments(self, *args, **kwargs):
         r"""
         Returns an instance of :class:`~apraw.models.ListingGenerator` mapped to the comments endpoint.
@@ -220,7 +220,7 @@ class Subreddit(aPRAWBase):
         return ListingGenerator(self._reddit, API_PATH["subreddit_comments"].format(sub=self.display_name),
                                 subreddit=self, *args, **kwargs)
 
-    @Streamable.streamable
+    @streamable
     def new(self, *args, **kwargs):
         r"""
         Returns an instance of :class:`~apraw.models.ListingGenerator` mapped to the new submissions endpoint.

--- a/apraw/models/subreddit/wiki.py
+++ b/apraw/models/subreddit/wiki.py
@@ -1,7 +1,7 @@
 from typing import TYPE_CHECKING, Dict, List, Union
 
 from ..helpers.apraw_base import aPRAWBase
-from ..helpers.streamable import Streamable
+from ..helpers.streamable import streamable
 from ..reddit.redditor import Redditor
 from ...const import API_PATH
 
@@ -16,7 +16,7 @@ class SubredditWiki:
         self.subreddit = subreddit
         self._data = None
 
-    @Streamable.streamable
+    @streamable
     def revisions(self, *args, **kwargs):
         r"""
         Returns an instance of :class:`~apraw.models.ListingGenerator` mapped to recent wikipage revisions.
@@ -76,7 +76,7 @@ class SubredditWikipage(aPRAWBase):
         self.name = name
         self.subreddit = subreddit
 
-    @Streamable.streamable
+    @streamable
     def revisions(self, *args, **kwargs):
         r"""
         Returns an instance of :class:`~apraw.models.ListingGenerator` mapped to fetch specific wikipage revisions.

--- a/apraw/models/user.py
+++ b/apraw/models/user.py
@@ -5,7 +5,7 @@ import aiohttp
 
 from .helpers.apraw_base import aPRAWBase
 from .helpers.generator import ListingGenerator
-from .helpers.streamable import Streamable
+from .helpers.streamable import streamable
 from .reddit.redditor import Redditor
 from ..endpoints import API_PATH
 
@@ -190,15 +190,15 @@ class AuthenticatedUser(Redditor):
             self._karma = [Karma(self.reddit, d) for d in resp["data"]]
         return self._karma
 
-    @Streamable.streamable
+    @streamable
     async def inbox(self, *args, **kwargs) -> ListingGenerator:
         return ListingGenerator(self.reddit, API_PATH["message_inbox"], *args, **kwargs)
 
-    @Streamable.streamable
+    @streamable
     async def sent(self, *args, **kwargs) -> ListingGenerator:
         return ListingGenerator(self.reddit, API_PATH["message_sent"], *args, **kwargs)
 
-    @Streamable.streamable
+    @streamable
     async def unread(self, *args, **kwargs) -> ListingGenerator:
         return ListingGenerator(self.reddit, API_PATH["message_unread"], *args, **kwargs)
 

--- a/apraw/reddit.py
+++ b/apraw/reddit.py
@@ -10,7 +10,7 @@ from multidict import CIMultiDictProxy
 
 from .endpoints import API_PATH, BASE_URL
 from .models import (Comment, Listing, Redditor, Submission,
-                     Subreddit, User, ListingGenerator, Streamable)
+                     Subreddit, User, ListingGenerator, streamable)
 from .utils import prepend_kind
 
 if os.path.exists('praw.ini'):
@@ -80,7 +80,7 @@ class Reddit:
         self.loop = asyncio.get_event_loop()
         self.request_handler = RequestHandler(self.user)
 
-    @Streamable.streamable
+    @streamable
     def subreddits(self, *args, **kwargs):
         r"""
         A :class:`~apraw.models.ListingGenerator` that returns newly created subreddits, which can be streamed using :code:`reddit.subreddits.stream()`.

--- a/tests/unit/models/helpers/test_streamable.py
+++ b/tests/unit/models/helpers/test_streamable.py
@@ -1,6 +1,6 @@
 import pytest
 
-from apraw.models import Streamable
+from apraw.models import Streamable, streamable
 
 
 class TestStreamable:
@@ -8,7 +8,7 @@ class TestStreamable:
     async def test_streamable_parameters(self):
         items = list(range(20))
 
-        @Streamable.streamable(max_wait=12)
+        @streamable(max_wait=12)
         async def async_generator():
             for i in items:
                 yield i


### PR DESCRIPTION
Closes #87

## Feature Summary
> Explain what's new in this pull request.

To combat the `class Streamable` being set as a class attribute due to the use of the descriptor protocol, a `class ProxyStreamable` has been created which sets the value of the instance attribute the first time it's called. The `class Streamable` has been simplified to only manage the `__call__()` and `stream()` logic.

In order for this proxy to be able to be applied to non-bound functions it implements `__call__()` and `stream()` as well and yields the results of a newly generated `class Streamable`.