### PR TITLE
Fix Return in Message Function

### DIFF
--- a/apraw/reddit.py
+++ b/apraw/reddit.py
@@ -282,7 +282,7 @@ class Reddit:
         return await Redditor(self, {"username": username}).fetch()
 
     async def message(self, to: Union[str, Redditor], subject: str, text: str,
-                      from_sr: Union[str, Subreddit] = "") -> Dict:
+                      from_sr: Union[str, Subreddit] = "") -> bool:
         """
         Message a Redditor or Subreddit.
 
@@ -310,7 +310,7 @@ class Reddit:
         if from_sr != "":
             data["from_sr"] = str(from_sr)
         resp = await self.post_request(API_PATH["compose"], data=data)
-        return resp["success"]
+        return not resp["json"]["errors"]
 
 
 class RequestHandler:

--- a/tests/integration/models/test_redditor.py
+++ b/tests/integration/models/test_redditor.py
@@ -37,3 +37,9 @@ class TestRedditor:
                 break
 
         assert submission_found
+
+    @pytest.mark.asyncio
+    async def test_redditor_message(self, reddit):
+        redditor = await reddit.redditor("aprawbot")
+        success = await redditor.message("Subject", "Body.")
+        assert success


### PR DESCRIPTION
Closes #89 

## Feature Summary
> Explain what's new in this pull request.

Returning success bool based on response error contents instead of `"success"` key.

## Tests Added
> Describe tests if any were written.

`test_redditor_message`: Tests whether `Redditor.message()` returns `True` for successfully sent messages.