### PR TITLE
Fix Message Class Mixin Initialization

### DIFF
--- a/apraw/models/reddit/message.py
+++ b/apraw/models/reddit/message.py
@@ -13,3 +13,5 @@ class Message(aPRAWBase, SubredditMixin, AuthorMixin, ReplyableMixin):
 
     def __init__(self, reddit: 'Reddit', data: Dict[str, Any]):
         super().__init__(reddit, data, reddit.message_kind)
+        AuthorMixin.__init__(self)
+        SubredditMixin.__init__(self)

--- a/tests/integration/models/test_message.py
+++ b/tests/integration/models/test_message.py
@@ -1,0 +1,15 @@
+import pytest
+
+import apraw
+
+
+class TestMessage:
+    @pytest.mark.asyncio
+    async def test_message_author(self, reddit: apraw.Reddit):
+        user = await reddit.user.me()
+
+        async for message in user.inbox():
+            if isinstance(message, apraw.models.Message):
+                author = await message.author()
+                assert isinstance(author, apraw.models.Redditor)
+                break


### PR DESCRIPTION
Close #90 

## Feature Summary
> Explain what's new in this pull request.

Mixin classes `class AuthorMixin` and `class SubredditMixin` are initialized in `class Message` to ensure proper functionality.

## Tests Added
> Describe tests if any were written.

`test_message_author`: Tests whether `Message.author()` returns a `class Redditor`.