### PR TITLE
Fixed spoiler issue

### DIFF
--- a/apraw/models/mixins/spoilerable.py
+++ b/apraw/models/mixins/spoilerable.py
@@ -6,7 +6,7 @@ class SpoilerableMixin:
     Mixin for spoilerable objects.
     """
 
-    async def spoiler(self):
+    async def mark_spoiler(self):
         """
         Mark the item as a spoiler.
 

--- a/apraw/models/mixins/spoilerable.py
+++ b/apraw/models/mixins/spoilerable.py
@@ -17,7 +17,7 @@ class SpoilerableMixin:
         """
         return await self.reddit.post_request(API_PATH["post_spoiler"], id=self.fullname)
 
-    async def unspoiler(self):
+    async def unmark_spoiler(self):
         """
         Unmark the item as a spoiler.
 

--- a/tests/integration/models/test_submission_moderation.py
+++ b/tests/integration/models/test_submission_moderation.py
@@ -52,12 +52,12 @@ class TestSubmissionModeration:
     @pytest.mark.asyncio
     async def test_submission_mod_spoiler(self, reddit):
         submission = await reddit.submission("h7mna9")
-        await submission.mod.spoiler()
+        await submission.mod.mark_spoiler()
         submission = await reddit.submission("h7mna9")
 
         assert submission._data["spoiler"]
 
-        await submission.mod.unspoiler()
+        await submission.mod.unmark_spoiler()
         submission = await reddit.submission("h7mna9")
 
         assert not submission._data["spoiler"]


### PR DESCRIPTION
Renamed submission.spoiler() to submission.mark_spoiler() to avoid clashing with spoiler attribute of Submission.
