### PR TITLE
Add Support for /r/mod and /r/all Listings.

### DIFF
--- a/apraw/models/subreddit/subreddit.py
+++ b/apraw/models/subreddit/subreddit.py
@@ -4,7 +4,7 @@ from .moderation import SubredditModerator, SubredditModeration
 from .modmail import SubredditModmail
 from .wiki import SubredditWiki
 from ..helpers.apraw_base import aPRAWBase
-from ..helpers.streamable import Streamable, streamable
+from ..helpers.streamable import streamable
 from ...const import API_PATH
 
 if TYPE_CHECKING:
@@ -163,9 +163,26 @@ class Subreddit(aPRAWBase):
         self: Subreddit
             The ``Subreddit`` model with updated data.
         """
+        if self.display_name.lower() in ["mod", "all"]:
+            return self
+
         resp = await self._reddit.get_request(API_PATH["subreddit_about"].format(sub=self.display_name))
         self._update(resp["data"])
         return self
+
+    def __repr__(self):
+        """
+        Get a representational string for this subreddit following the pattern ``<{class} {id_attribute}='{id}'>``.
+
+        Returns
+        -------
+        repr: string
+            A printable representational string for this model.
+        """
+        if self.display_name.lower() in ["mod", "all"]:
+            return f"<Subreddit /r/{self.display_name}>"
+
+        return super().__repr__()
 
     def _update(self, data: Dict[str, Any]):
         """

--- a/tests/integration/models/test_subreddit.py
+++ b/tests/integration/models/test_subreddit.py
@@ -61,3 +61,21 @@ class TestSubreddit:
         subreddit = await reddit.subreddit("aprawtest")
         submission = await subreddit.random()
         assert isinstance(submission, apraw.models.Submission)
+
+    @pytest.mark.asyncio
+    async def test_subreddit_all(self, reddit):
+        subreddit = await reddit.subreddit("all")
+
+        count = 0
+        async for submission in subreddit.new(limit=5):
+            count += 1
+            assert isinstance(submission, apraw.models.Submission)
+
+        assert count == 5
+
+    @pytest.mark.asyncio
+    async def test_subreddit_mod(self, reddit):
+        subreddit = await reddit.subreddit("mod")
+
+        async for submission in subreddit.new(limit=5):
+            assert isinstance(submission, apraw.models.Submission)


### PR DESCRIPTION
Closes #95

## Feature Summary
> Explain what's new in this pull request.

Special subreddits (such as those with the name "mod" or "all") won't load data to enable the use of their listing endpoints. Trying to access attributes such as `id` and `fullname` will generate errors.

## Tests Added
> Describe tests if any were written.

 - `test_subreddit_all`
 - `test_subreddit_mod`