### PR TITLE
Add Support to fetch Modmail by ID

### DIFF
--- a/apraw/models/subreddit/subreddit.py
+++ b/apraw/models/subreddit/subreddit.py
@@ -152,7 +152,7 @@ class Subreddit(aPRAWBase):
         super().__init__(reddit, data, reddit.subreddit_kind)
 
         self.mod = SubredditModeration(self._reddit, self)
-        self.modmail = SubredditModmail(self)
+        self.modmail = SubredditModmail(self._reddit, self)
         self.wiki = SubredditWiki(self._reddit, self)
         self.removal_reasons = SubredditRemovalReasons(self._reddit, self)
 

--- a/apraw/reddit.py
+++ b/apraw/reddit.py
@@ -238,10 +238,10 @@ class Reddit:
         -------
         subreddit: Subreddit
             The subreddit if found.
-        result: None
-            Returns None if subreddit not found.
         """
-        return await Subreddit(self, {"display_name": display_name}).fetch()
+        sub = Subreddit(self, {"display_name": display_name})
+        await sub.fetch()
+        return sub
 
     async def info(self, id: str = "", ids: List[str] = [], url: str = ""):
         """

--- a/apraw/request_handler.py
+++ b/apraw/request_handler.py
@@ -1,7 +1,7 @@
 import asyncio
 from datetime import datetime, timedelta
 from functools import wraps
-from typing import Dict, Callable, Any, Awaitable
+from typing import Dict, Callable, Any, Awaitable, Optional
 
 from multidict import CIMultiDictProxy
 
@@ -74,11 +74,16 @@ class RequestHandler:
             return execute_request
 
     @Decorators.check_ratelimit
-    async def get(self, endpoint: str = "", **kwargs) -> Any:
+    async def get(self, endpoint: Optional[str] = "", _url: Optional[str] = "", **kwargs) -> Any:
         kwargs = {"raw_json": 1, "api_type": "json", **kwargs}
         params = ["{}={}".format(k, kwargs[k]) for k in kwargs]
 
-        url = BASE_URL.format(endpoint, "&".join(params))
+        if endpoint:
+            url = BASE_URL.format(endpoint, "&".join(params))
+        elif _url:
+            url = _url + "?" + "&".join(params)
+        else:
+            raise ValueError("One of endpoint or _url must be specified.")
 
         headers = await self.get_request_headers()
         session = await self.user.client_session()

--- a/docs/api/models/subreddit/modmail.rst
+++ b/docs/api/models/subreddit/modmail.rst
@@ -18,6 +18,7 @@ SubredditModmail
 
 .. autoclass:: apraw.models.SubredditModmail
     :members:
+    :special-members: __call__
 
 ModmailConversation
 -------------------

--- a/requests/requests.http
+++ b/requests/requests.http
@@ -101,3 +101,13 @@ GET {{baseUrl}}/r/{{subreddit}}/about/edit
 User-Agent: {{user_agent}}
 Content-Type: application/json
 Authorization: {{getToken.response.body.token_type}} {{getToken.response.body.access_token}}
+
+###
+
+@conversationId = eqjy3
+
+# @name getModmailConversation
+GET {{baseUrl}}/api/mod/conversations/{{conversationId}}
+User-Agent: {{user_agent}}
+Content-Type: application/json
+Authorization: {{getToken.response.body.token_type}} {{getToken.response.body.access_token}}

--- a/tests/integration/models/test_subreddit.py
+++ b/tests/integration/models/test_subreddit.py
@@ -125,3 +125,17 @@ class TestSubreddit:
 
         settings = await subreddit.mod.settings()
         assert settings.title.lower() == "aprawtest"
+
+    @pytest.mark.asyncio
+    async def test_subreddit_modmail(self, reddit: apraw.Reddit):
+        subreddit = await reddit.subreddit("aprawtest")
+
+        conv = None
+        async for conv in subreddit.modmail.conversations():
+            assert isinstance(conv, apraw.models.ModmailConversation)
+
+        assert conv
+
+        if conv:
+            c = await subreddit.modmail(conv.id)
+            assert isinstance(c, apraw.models.ModmailConversation)


### PR DESCRIPTION
Closes #108 

## Feature Summary
> Explain what's new in this pull request.

 - Add `_url` param to `RequestHandler.get()`.
 - Add `SubredditModmail.__call__()` to retrieve modmail by ID.
   * Add docsection for `__call__`.
 - Add `_reddit` private member to `class SubredditModmail`.

## Tests Added
> Describe tests if any were written.

 - `test_subreddit_modmail`