### PR TITLE
Add Support for Fetching Submissions and Comments by URL

### DIFF
--- a/apraw/models/helpers/apraw_base.py
+++ b/apraw/models/helpers/apraw_base.py
@@ -95,4 +95,4 @@ class aPRAWBase:
         fullname: str
             The item's ID prepended with its kind such as `t1_`.
         """
-        return getattr(self, "name") or prepend_kind(self._data[self.ID_ATTRIBUTE], self.kind)
+        return getattr(self, "name", None) or prepend_kind(self._data[self.ID_ATTRIBUTE], self.kind)

--- a/apraw/reddit.py
+++ b/apraw/reddit.py
@@ -294,12 +294,13 @@ class Reddit:
             The requested submission.
         """
         if id != "":
-            async for link in self.info(prepend_kind(id, self.link_kind)):
-                return link
-        elif url != "":
-            async for link in self.info(url=url):
-                return link
-        return None
+            submission = Submission(self, {"id": id})
+            await submission.fetch()
+            return submission
+        else:
+            submission = Submission(self, {"url": url})
+            await submission.fetch()
+            return submission
 
     async def comment(self, id: str = "", url: str = "") -> Comment:
         """

--- a/tests/integration/test_reddit.py
+++ b/tests/integration/test_reddit.py
@@ -14,9 +14,15 @@ class TestReddit:
         submission = await reddit.submission("h7mna9")
         assert submission.title == "Test Post"
 
+        submission = await reddit.submission(url="https://www.reddit.com/r/aPRAWTest/comments/h7mna9/test_post/")
+        assert submission.title == "Test Post"
+
     @pytest.mark.asyncio
     async def test_reddit_comment(self, reddit: apraw.Reddit):
         comment = await reddit.comment("fuoew5r")
+        assert comment.body == "Test comment by bot."
+
+        comment = await reddit.comment(url="https://www.reddit.com/r/aPRAWTest/comments/h7mna9/test_post/fuoew5r")
         assert comment.body == "Test comment by bot."
 
     @pytest.mark.asyncio


### PR DESCRIPTION
Closes #107 

## Feature Summary
> Explain what's new in this pull request.

 - Fix `Reddit.comment()` and `Reddit.submission()` with `url` parameter.
 - Optimize `Submission._update()`.
 - Fix `aPRAWBase.fullname` property to use `ID_ATTRIBUTE` if `name` not present.

## Tests

Extended `test_reddit_comment` and `test_reddit_submission` to test `Reddit.comment()`/`Reddit.submission()` by URL.