### PR TITLE
Fix ModAction.mod()

### DIFF
--- a/apraw/models/subreddit/moderation.py
+++ b/apraw/models/subreddit/moderation.py
@@ -330,4 +330,4 @@ class ModAction(aPRAWBase):
         redditor: Redditor
             The Redditor who performed this action.
         """
-        return await self.subreddit._reddit.redditor(self.mod)
+        return await self.subreddit._reddit.redditor(self._data["mod"])

--- a/tests/integration/models/test_subreddit.py
+++ b/tests/integration/models/test_subreddit.py
@@ -169,3 +169,13 @@ class TestSubreddit:
                 found = True
             assert found
 
+    @pytest.mark.asyncio
+    async def test_subreddit_mod_log(self, reddit: apraw.Reddit):
+        subreddit = await reddit.subreddit("aprawtest")
+
+        async for action in subreddit.mod.log():
+            assert isinstance(action, apraw.models.ModAction)
+
+        assert action
+
+        assert isinstance(await action.mod(), apraw.models.Redditor)


### PR DESCRIPTION
Fixes #122

## Feature Summary
> Explain what's new in this pull request.

Explicitly using `ModAction._data["mod"]` to retrieve moderator's name.

## Tests Added
> Describe tests if any were written.

 - `test_subreddit_mod_log`