### PR TITLE
Fix issue with setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ with open('apraw/const.py') as f:
     version = re.search(r'^__version__\s*=\s*[\'"]([^\'"]*)[\'"]', f.read(), re.MULTILINE).group(1)
 tag = ''
 with open('apraw/const.py') as f:
-    tag = re.search(r'^__version__\s*=\s*[\'"]([^\'"]*)[\'"]', f.read(), re.MULTILINE).group(1)
+    tag = re.search(r'^__tag__\s*=\s*[\'"]([^\'"]*)[\'"]', f.read(), re.MULTILINE).group(1)
 
 if not version:
     raise RuntimeError("version is not set")

--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,22 @@
 import setuptools
-from apraw import __version__, __tag__
+import re
 
 with open("README.md", "r", encoding="utf8") as fh:
     long_description = fh.read()
 
+version = ''
+with open('apraw/const.py') as f:
+    version = re.search(r'^__version__\s*=\s*[\'"]([^\'"]*)[\'"]', f.read(), re.MULTILINE).group(1)
+tag = ''
+with open('apraw/const.py') as f:
+    tag = re.search(r'^__version__\s*=\s*[\'"]([^\'"]*)[\'"]', f.read(), re.MULTILINE).group(1)
+
+if not version:
+    raise RuntimeError("version is not set")
+
 setuptools.setup(
     name="aPRAW",
-    version="{}-{}".format(__version__, __tag__) if __tag__ else __version__,
+    version="{}-{}".format(version, tag) if tag else version,
     author="Dan6erbond",
     author_email="moravrav@gmail.com",
     description="aPRAW is an asynchronous Reddit API wrapper written in Python.",

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,9 @@ with open('apraw/const.py') as f:
     version = re.search(r'^__version__\s*=\s*[\'"]([^\'"]*)[\'"]', f.read(), re.MULTILINE).group(1)
 tag = ''
 with open('apraw/const.py') as f:
-    tag = re.search(r'^__tag__\s*=\s*[\'"]([^\'"]*)[\'"]', f.read(), re.MULTILINE).group(1)
+    tag = re.search(r'^__tag__\s*=\s*[\'"]([^\'"]*)[\'"]', f.read(), re.MULTILINE)
+    if tag:
+        tag = tag.group(1)
 
 if not version:
     raise RuntimeError("version is not set")


### PR DESCRIPTION
Fixes # (provide issue number if applicable)
When installing the module with setup.py the import for `__version__` and `__tag__` end up attempting to import a module that has not necessarily been installed yet causing it to fail. This fixes the issue. You can find more details on why it's done this way here: https://packaging.python.org/guides/single-sourcing-package-version/#single-sourcing-the-version
